### PR TITLE
Load Flux Spack environment automatically at login

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -32,22 +32,17 @@ jobs:
           export COMPOSE_HTTP_TIMEOUT=600
           docker-compose -f docker-compose.yml up --build -d 
       -
-        name: Create ssh keys in cluster
-        run: |
-          docker exec frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
-          docker exec frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
-      -
         name: Copy test scripts to work directory
         run: |
           docker exec frontend bash -l -c "mkdir -p work; cd work ; cp ../test/*.py . ; cp ../test/*.f90 ."
       -
         name: Parsl hello test
         run: |
-          docker exec frontend bash -l -c "spack env activate flux; cd work ; ./parsl_hello.py"
+          docker exec frontend bash -l -c "cd work ; ./parsl_hello.py"
       -
         name: Parsl/Flux hello MPI test
         run: |
-          docker exec frontend bash -l -c "spack env activate flux; cd work ; ./parsl_mpi_flux_hello.py"
+          docker exec frontend bash -l -c "cd work ; ./parsl_mpi_flux_hello.py"
           docker exec frontend bash -l -c "cat work/resource_list.txt"
           docker exec frontend bash -l -c "cat work/mpi_apps.hello.out"
       -

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -46,6 +46,7 @@ RUN . /opt/spack/share/spack/setup-env.sh \
 
 # Set up user shell init
 RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
+ && echo "spack env activate flux" >> /home/admin/.bash_profile \
  && echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && chown admin:admin /home/admin/.bash_profile
 

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -5,5 +5,6 @@ RUN apt-get update -y && apt-get install -y \
 
 # Set up user shell init
 RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
- && echo "source /opt/intel/oneapi/setvars.sh" >> /home/admin/.bash_profile \
+ && echo "spack env activate flux" >> /home/admin/.bash_profile \
+ && echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && chown admin:admin /home/admin/.bash_profile

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update -y && apt-get install -y \
 
 # Set up user shell init
 RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
- && echo "source /opt/intel/oneapi/setvars.sh" >> /home/admin/.bash_profile \
+ && echo "spack env activate flux" >> /home/admin/.bash_profile \
+ && echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && chown admin:admin /home/admin/.bash_profile
-
-RUN echo "hello world" >> /home/admin/hello


### PR DESCRIPTION
Update Dockerfiles and CI workflow to remove loading of Flux Spack environment.  These containers are designed to run with Flux and Parsl so it makes sense to load the Spack flux environment at login rather than having to do it manually every time a command is run via `docker exec` or when logging into an interactive session in the frontend container.

In addition, creation of ssh keys is removed from the CI because the upstream base containers were updated such that the keys are already created.  There is no longer a need to create ssh keys.