### PR TITLE
Make install scripts portable

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -26,23 +26,25 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends -o=Dpkg::Use
     intel-oneapi-compiler-fortran \
     intel-oneapi-mpi-devel
 
+# Create directory in /opt for Spack install
+RUN mkdir -p /opt/spack \
+ && chown admin:admin /opt/spack
+
 # Copy the install scripts
 COPY ./install /tmp/install
 
-# Install Spack
-RUN cd /tmp/install \
- && ./install_spack.sh /opt/spack v0.19.2 \
- && chown -R admin:admin /opt/spack
-
 USER admin
 SHELL ["/bin/bash", "-c"]
+
+# Install Spack
+RUN cd /tmp/install \
+ && ./install_spack.sh /opt/spack v0.19.2
 
 # Install the Spack Parsl/Flux environment
 RUN . /opt/spack/share/spack/setup-env.sh \
  && cd /tmp/install \
  && ./install_bootstrap.sh \
  && ./install_base.sh \
- && ./install_flux_parsl.sh \
  && ./install_flux_parsl.sh
 
 # Set up user shell init

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -42,6 +42,7 @@ RUN . /opt/spack/share/spack/setup-env.sh \
  && cd /tmp/install \
  && ./install_bootstrap.sh \
  && ./install_base.sh \
+ && ./install_flux_parsl.sh \
  && ./install_flux_parsl.sh
 
 # Set up user shell init

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -47,6 +47,11 @@ RUN . /opt/spack/share/spack/setup-env.sh \
  && ./install_base.sh \
  && ./install_flux_parsl.sh
 
+# Re-install the Spack Parsl/Flux environment to work around bug
+RUN . /opt/spack/share/spack/setup-env.sh \
+ && cd /tmp/install \
+ && ./install_flux_parsl.sh
+
 # Set up user shell init
 RUN echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -26,23 +26,24 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends -o=Dpkg::Use
     intel-oneapi-compiler-fortran \
     intel-oneapi-mpi-devel
 
-# Install Spack
-RUN git clone -c feature.manyFiles=true -c core.sharedRepository=true https://github.com/spack/spack.git /opt/spack \
- && cd /opt/spack \
- && git checkout v0.19.2 \
- && chgrp -R admin /opt/spack \
- && chmod -R g+rw /opt/spack
-
 # Copy the install scripts
 COPY ./install /tmp/install
+
+# Install Spack
+RUN cd /tmp/install
+ && ./install_spack /opt/spack v0.19.2 \
+ && chgrp -R admin /opt/spack \
+ && chmod -R g+rw /opt/spack
 
 USER admin
 SHELL ["/bin/bash", "-c"]
 
 # Install the Spack Parsl/Flux environment
-RUN . /opt/spack/share/spack/setup-env.sh \
- && cd /tmp/install \
- && ./install.sh
+RUN cd /tmp/install \
+ && . /opt/spack/share/spack/setup-env.sh \
+ && ./install_bootstrap.sh \
+ && ./install_base.sh \
+ && ./install_flux_parsl.sh
 
 # Set up user shell init
 RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -32,8 +32,7 @@ COPY ./install /tmp/install
 # Install Spack
 RUN cd /tmp/install \
  && ./install_spack.sh /opt/spack v0.19.2 \
- && chgrp -R admin /opt/spack \
- && chmod -R g+rw /opt/spack
+ && chown -R admin:admin /opt/spack
 
 USER admin
 SHELL ["/bin/bash", "-c"]
@@ -41,12 +40,14 @@ SHELL ["/bin/bash", "-c"]
 # Install the Spack Parsl/Flux environment
 RUN . /opt/spack/share/spack/setup-env.sh \
  && cd /tmp/install \
+ && ./install_bootstrap.sh \
+ && ./install_base.sh \
  && ./install_flux_parsl.sh
 
 # Set up user shell init
-RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
+RUN echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
+ && echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
  && echo "spack env activate flux" >> /home/admin/.bash_profile \
- && echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && chown admin:admin /home/admin/.bash_profile
 
 SHELL ["/bin/bash"]

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends -o=Dpkg::Use
 COPY ./install /tmp/install
 
 # Install Spack
-RUN cd /tmp/install
- && ./install_spack /opt/spack v0.19.2 \
+RUN cd /tmp/install \
+ && ./install_spack.sh /opt/spack v0.19.2 \
  && chgrp -R admin /opt/spack \
  && chmod -R g+rw /opt/spack
 

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -39,10 +39,8 @@ USER admin
 SHELL ["/bin/bash", "-c"]
 
 # Install the Spack Parsl/Flux environment
-RUN cd /tmp/install \
- && . /opt/spack/share/spack/setup-env.sh \
- && ./install_bootstrap.sh \
- && ./install_base.sh \
+RUN . /opt/spack/share/spack/setup-env.sh
+ && cd /tmp/install \
  && ./install_flux_parsl.sh
 
 # Set up user shell init

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -39,7 +39,7 @@ USER admin
 SHELL ["/bin/bash", "-c"]
 
 # Install the Spack Parsl/Flux environment
-RUN . /opt/spack/share/spack/setup-env.sh
+RUN . /opt/spack/share/spack/setup-env.sh \
  && cd /tmp/install \
  && ./install_flux_parsl.sh
 

--- a/docker/install/install_base.sh
+++ b/docker/install/install_base.sh
@@ -1,0 +1,62 @@
+#!/bin/env bash
+
+# These can be customized to suit individual needs
+DEFAULT_GCC_VERSION=$(gcc --version | head -1 | sed -e 's/([^()]*)//g' | awk '{print $2}')  # Version of system default gcc
+DEFAULT_COMPILER="gcc@${DEFAULT_GCC_VERSION}"  # Default system compiler used to build newer gcc
+
+SPACK_ENV_NAME="base"            # Name of spack environment to create
+SPACK_ENV_COMPILER="gcc@9.4.0"  # Compiler to use to build the spack environment
+TARGET_ARCH_OPT="target=x86_64"  # Compiler architecture build target
+
+################################################################################
+# help                                                                         #
+################################################################################
+help()
+{
+  # Display help
+  echo "Installs a base Spack environment to use for building exaworks packages." 
+  echo "This includes: gcc"
+  echo
+  echo "Usage: install_base.sh"
+  echo
+}
+
+# Get the location of Spack so we can update permissions
+if [[ $(which spack 2>/dev/null) ]]; then
+  SPACK_DIR=$(dirname $(dirname $(which spack)))
+else
+  echo "Cannot find Spack."
+  echo
+  echo "Please install Spack and/or source Spack's environment setup script: .../spack/share/setup-env.sh"
+  echo
+  exit 1
+fi
+
+set -eu
+
+if [ "${SPACK_ENV_COMPILER}" == "${DEFAULT_COMPILER}" ]; then
+    echo "${SPACK_ENV_COMPILER} is the default compiler, no need to install it"
+else
+  # Configure spack
+  spack config add concretizer:unify:true
+  spack config add concretizer:reuse:true
+  spack config add config:db_lock_timeout:300
+  spack config add config:install_tree:padded_length:128
+  
+  # Get the location of the bootstrap compiler
+  BOOTSTRAP_COMPILER=$(spack location -i ${SPACK_ENV_COMPILER}%${DEFAULT_COMPILER})
+  
+  # Create the base environment
+  spack env create ${SPACK_ENV_NAME} || true
+  spack env activate ${SPACK_ENV_NAME}
+  spack compiler add ${BOOTSTRAP_COMPILER}
+  
+  # Use the bootstrap compiler to install the compiler in the base environment
+  spack add ${SPACK_ENV_COMPILER}%${SPACK_ENV_COMPILER} ${TARGET_ARCH_OPT}
+  spack concretize
+  spack install
+  spack env deactivate
+  spack compiler add $(spack location -i ${SPACK_ENV_COMPILER}%${SPACK_ENV_COMPILER})
+fi
+
+exit 0

--- a/docker/install/install_bootstrap.sh
+++ b/docker/install/install_bootstrap.sh
@@ -1,0 +1,58 @@
+#!/bin/env bash
+
+# These can be customized to suit individual needs
+DEFAULT_GCC_VERSION=$(gcc --version | head -1 | sed -e 's/([^()]*)//g' | awk '{print $2}')  # Version of system default gcc
+DEFAULT_COMPILER="gcc@${DEFAULT_GCC_VERSION}"  # Default system compiler used to build newer gcc
+
+SPACK_ENV_NAME="base"            # Name of spack environment to create
+SPACK_ENV_COMPILER="gcc@9.4.0"  # Compiler to use to build the spack environment
+TARGET_ARCH_OPT="target=x86_64"  # Compiler architecture build target
+
+################################################################################
+# help                                                                         #
+################################################################################
+help()
+{
+  # Display help
+  echo "Installs a bootstrap compiler built by the default system compiler into a bootstrap environment."
+  echo "This bootstrap compiler can then be used to build other packages without incurring"
+  echo "dependencies on the system default compiler."
+  echo
+  echo "Usage: install_bootstrap.sh"
+  echo
+}
+
+# Get the location of Spack so we can update permissions
+if [[ $(which spack 2>/dev/null) ]]; then
+  SPACK_DIR=$(dirname $(dirname $(which spack)))
+else
+  echo "Cannot find Spack."
+  echo
+  echo "Please install Spack and/or source Spack's environment setup script: .../spack/share/setup-env.sh"
+  echo
+  exit 1
+fi
+
+set -eu
+
+# Install a bootstrap compiler if it's not already the system default
+if [ "${SPACK_ENV_COMPILER}" == "${DEFAULT_COMPILER}" ]; then
+    echo "${SPACK_ENV_COMPILER} is the default compiler, no need to install it"
+else
+  # Configure spack
+  spack config add concretizer:unify:true
+  spack config add concretizer:reuse:true
+  spack config add config:db_lock_timeout:300
+  spack config add config:install_tree:padded_length:128
+  
+  # Create a compiler bootstrap environment
+  spack env create bootstrap || true
+  spack env activate bootstrap
+  spack compiler find
+  
+  # Install bootstrap $COMPILER in bootstrap environment
+  spack add ${SPACK_ENV_COMPILER}%${DEFAULT_COMPILER} ${TARGET_ARCH_OPT}
+  spack install
+fi
+
+exit 0

--- a/docker/install/install_flux_parsl.sh
+++ b/docker/install/install_flux_parsl.sh
@@ -61,4 +61,10 @@ spack install
 # Install Parsl
 python3 -m pip install parsl
 
+# Refresh the Spack environment view to recover PYTHONPATH and CPATH
+spack add flux-core@0.53.0%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
+spack add flux-sched@0.28.0%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
+spack add py-pip%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
+spack install
+
 exit 0

--- a/docker/install/install_flux_parsl.sh
+++ b/docker/install/install_flux_parsl.sh
@@ -61,10 +61,4 @@ spack install
 # Install Parsl
 python3 -m pip install parsl
 
-# Refresh the Spack environment view to recover PYTHONPATH and CPATH
-spack add flux-core@0.53.0%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
-spack add flux-sched@0.28.0%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
-spack add py-pip%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
-spack install
-
 exit 0

--- a/docker/install/install_flux_parsl.sh
+++ b/docker/install/install_flux_parsl.sh
@@ -39,6 +39,11 @@ spack config add concretizer:reuse:true
 spack config add config:db_lock_timeout:300
 spack config add config:install_tree:padded_length:128
 
+# Add Spack-built compilers if necessary
+if [ "${SPACK_ENV_COMPILER}" != "${DEFAULT_COMPILER}" ]; then
+  spack compiler add $(spack location -i ${SPACK_ENV_COMPILER}%${SPACK_ENV_COMPILER})
+fi
+
 # Configure spack environment
 spack env create ${SPACK_ENV_NAME} || true
 spack env activate ${SPACK_ENV_NAME}
@@ -48,9 +53,11 @@ spack add flux-core@0.53.0%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OP
 spack add flux-sched@0.28.0%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
 spack concretize
 spack install --no-checksum
+
 # Install pip
 spack add py-pip%${SPACK_ENV_COMPILER} ^python@3.9.15 ${TARGET_ARCH_OPT}
 spack install
+
 # Install Parsl
 python3 -m pip install parsl
 

--- a/docker/install/install_spack.sh
+++ b/docker/install/install_spack.sh
@@ -1,0 +1,49 @@
+#!/bin/env bash                                                                                                                                                                                                              
+
+################################################################################
+# help                                                                         #
+################################################################################
+help()
+{
+   # Display help
+   echo "Installs Spack"
+   echo
+   echo "Usage: install_spack.sh <install path> <tag>"
+   echo
+}
+
+# Get install path
+if [[ $# -ne 2 ]]; then
+  help
+  exit 1
+else
+  SPACK_DIR=$1
+  SPACK_VERSION=$2
+fi
+
+# Check for existing Spack configuration
+if [[ -d ~/.spack ]]; then
+  echo "Spack may already be installed."
+  echo
+  echo  "To reinstall Spack, please remove the existing configuration directory ~/.spack and try again"
+  exit 1
+fi
+
+# Check for existing Spack installation
+if [[ -d ${SPACK_DIR} ]]; then
+  echo "A Spack installation already exists at ${SPACK_DIR}."
+  echo
+  echo "Please choose another location or remove ${SPACK_DIR} and try again."
+  exit 1
+fi
+
+# Create empty installation directory
+[[ -d ${SPACK_DIR} ]] || mkdir -p ${SPACK_DIR}
+
+# Install Spack via repository clone
+git clone -c feature.manyFiles=true -c core.sharedRepository=true https://github.com/spack/spack.git ${SPACK_DIR}
+pushd ${SPACK_DIR}
+git checkout ${SPACK_VERSION}
+popd
+
+exit 0

--- a/docker/install/install_spack.sh
+++ b/docker/install/install_spack.sh
@@ -30,7 +30,7 @@ if [[ -d ~/.spack ]]; then
 fi
 
 # Check for existing Spack installation
-if [[ -d ${SPACK_DIR} ]]; then
+if [[ -d ${SPACK_DIR} && -n "$(ls -A ${SPACK_DIR})" ]]; then
   echo "A Spack installation already exists at ${SPACK_DIR}."
   echo
   echo "Please choose another location or remove ${SPACK_DIR} and try again."

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y \
     libpmi2-0-dev
 
 # Set up user shell init
-RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
+RUN echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
+ && echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
  && echo "spack env activate flux" >> /home/admin/.bash_profile \
- && echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && chown admin:admin /home/admin/.bash_profile

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install -y \
     libpmi2-0-dev
 
 # Set up user shell init
-RUN echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
+RUN echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
+ && echo ". /opt/spack/share/spack/setup-env.sh" >> /home/admin/.bash_profile \
  && echo "spack env activate flux" >> /home/admin/.bash_profile \
- && echo "source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1" >> /home/admin/.bash_profile \
  && chown admin:admin /home/admin/.bash_profile


### PR DESCRIPTION
The existing install scripts currently in use for building Docker containers are not portable because they assume that `gcc 9.4.0` is already installed on the system.  If that is not the case, the install will fail.  This PR introduces two more installation scripts to help make the install process more portable.  When the required compiler, `gcc 9.4.0`, is not available, a bootstrap compiler must be built and then used to install `gcc 9.4.0` before installing Flux and Parsl.  A `install_bootstrap.sh` install script is added to build and install the bootstrap compiler if one is needed.  This script builds and installs `gcc 9.4.0` with the system default compiler.  However, in order to make Spack build cache mirrors work correctly on potential destination machines with no internet access, we must remove the dependency on the default compiler.  This is done with `install_base.sh`.  The `install_base.sh` script then builds `gcc 9.4.0` again using the `gcc 9.4.0` compiler built by the bootstrap compiler.  This results in a clean version of `gcc 9.4.0` installed without any dependencies on libraries built with the default system compiler.  At this point, Parsl and Flux may be installed with no issues, and the environment is suitable for creation of Spack build cache that can be used on other systems.

The current containers used for CI testing already have `gcc 9.4.0` as the default compiler, so when `install_bootstrap.sh` and `install_base.sh` are installed in CI, there is no change in behavior, and the installations of the bootstrap compiler and `gcc 9.4.0` are skipped.  However, when installing on other HPC systems, the same install scripts that are used in CI will now correctly install the environment without modification.