### PR TITLE
Move configuration into platform YAML files

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -103,7 +103,7 @@ jobs:
       -
         name: Parsl/Flux hello MPI test
         run: |
-          docker exec frontend bash -l -c "cd work/src ; . /opt/conda_init.sh; conda activate chiltepin; ./parsl_flux_mpi_hello.py"
+          docker exec frontend bash -l -c "cd work/src ; . /opt/conda_init.sh; conda activate chiltepin; ./parsl_flux_mpi_hello.py chiltepin.yaml"
           docker exec frontend bash -l -c "diff work/src/parsl_flux_resource_list.txt work/output/parsl_flux_resource_list.txt.baseline"
           docker exec frontend bash -l -c "grep 'completed pmi barrier on 6 tasks' work/src/parsl_flux_pmi_barrier.txt"
           docker exec frontend bash -l -c "diff work/src/parsl_flux_mpi_hello_compile.out work/output/parsl_flux_mpi_hello_compile.out.baseline"

--- a/docker/install/chiltepin.yml
+++ b/docker/install/chiltepin.yml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - flux-core
   - flux-sched
+  - openmpi
   - openmpi-mpicc
   - openmpi-mpicxx
   - openmpi-mpifort

--- a/docker/install/install_miniconda.sh
+++ b/docker/install/install_miniconda.sh
@@ -23,4 +23,4 @@ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${
 bash ${MINICONDA_PATH}/miniconda.sh -b -u -p ${MINICONDA_PATH}
 rm -f ${MINICONDA_PATH}/miniconda.sh
 conda update -y conda
-conda init
+conda init bash

--- a/docker/test/src/chiltepin.yaml
+++ b/docker/test/src/chiltepin.yaml
@@ -1,0 +1,9 @@
+provider:
+  cores per node: 2
+  partition: "slurmpar"
+  account: ""
+
+environment:
+  - "export FLUX_PMI_LIBRARY_PATH=/opt/miniconda3/envs/chiltepin/lib/flux/libpmi.so"
+  - "export OMPI_MCA_btl=self,tcp"
+  - "export CHILTEPIN_MPIF90=mpif90"

--- a/docker/test/src/chiltepin_config.py
+++ b/docker/test/src/chiltepin_config.py
@@ -1,0 +1,45 @@
+from parsl.config import Config
+from parsl.channels import LocalChannel
+from parsl.providers import SlurmProvider
+from parsl.executors import FluxExecutor
+from parsl.launchers import SimpleLauncher
+
+import os
+
+def config_factory(yaml_config={}):
+
+    # Set FLUX_SSH
+    os.environ["FLUX_SSH"] = "ssh"
+
+    provider_config = yaml_config["provider"]
+    
+    cores_per_node=provider_config["cores per node"]
+    partition=provider_config["partition"]
+    account=provider_config["account"]
+
+    env_init="\n".join(yaml_config["environment"])
+
+    # Update to import config for your machine
+    config = Config(
+        executors=[
+            FluxExecutor(
+                label="flux",
+                # Start Flux with srun and tell it how many cores per node to expect
+                launch_cmd=f'srun --mpi=pmi2 --tasks-per-node=1 -c{cores_per_node} ' + FluxExecutor.DEFAULT_LAUNCH_CMD,
+                provider=SlurmProvider(
+                    channel=LocalChannel(),
+                    nodes_per_block=3,
+                    init_blocks=1,
+                    partition=partition,
+                    account=account,
+                    walltime='00:10:00',
+                    launcher=SimpleLauncher(),
+                    worker_init='''
+                    ''',
+                ),
+            )
+        ],
+    )
+
+    return config, env_init
+

--- a/docker/test/src/hercules.yaml
+++ b/docker/test/src/hercules.yaml
@@ -1,0 +1,10 @@
+provider:
+  cores per node: 20
+  partition: "hercules"
+  account: "gsd-hpcs"
+
+environment:
+  - "module load intel-oneapi-compilers/2023.1.0"
+  - "module load intel-oneapi-mpi/2021.7.1"
+  - "unset I_MPI_PMI_LIBRARY"
+  - "export CHILTEPIN_MPIF90='mpiifort -fc=ifx'"

--- a/docker/test/src/parsl_flux_mpi_hello.py
+++ b/docker/test/src/parsl_flux_mpi_hello.py
@@ -9,12 +9,13 @@ import yaml
 
 import chiltepin_config
 
+# Open and parse the yaml config
 with open(sys.argv[1], "r") as stream:
     try:
         yaml_config = yaml.safe_load(stream)
-    except yaml.YAMLError as exc:
+    except yaml.YAMLError as e:
         print("Invalid taml configuration")
-        raise(exc)
+        raise(e)
 
 # Load the configuration
 config, env_init = chiltepin_config.config_factory(yaml_config)
@@ -81,21 +82,5 @@ hello = mpi_hello(dirpath=shared_dir,
 # Wait for the MPI app with chiltepin stack to finish
 hello.result()
 
-## complile the app with spack-stack stack and wait for it to complete (.result())
-#compile_app(dirpath=shared_dir,
-#            stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.out"),
-#            stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.err"),
-#            stack=spack_stack,
-#           ).result()
-#
-## run the mpi app with spack-stack stack
-#hello = mpi_hello(dirpath=shared_dir,
-#                  stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.out"),
-#                  stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.err",),
-#                  stack=spack_stack,
-#                  parsl_resource_specification={"num_tasks": 6, "num_nodes": 3})
-#
-# Wait for the MPI app with spack-stack stack to finish
-#hello.result()
-
+# Cleanup
 parsl.clear()

--- a/docker/test/src/parsl_flux_mpi_hello.py
+++ b/docker/test/src/parsl_flux_mpi_hello.py
@@ -16,18 +16,16 @@ config = Config(
         FluxExecutor(
             label="flux",
             # Start Flux with srun and tell it there are 40 cores per node
-            launch_cmd='srun --mpi=pmi2 --tasks-per-node=1 -c2 ' + FluxExecutor.DEFAULT_LAUNCH_CMD,
+            launch_cmd='srun --mpi=pmi2 --tasks-per-node=1 -c20 ' + FluxExecutor.DEFAULT_LAUNCH_CMD,
             provider=SlurmProvider(
                 channel=LocalChannel(),
                 nodes_per_block=3,
                 init_blocks=1,
-                partition='slurmpar',
-                account='',
+                partition='hercules',
+                account='gsd-hpcs',
                 walltime='00:10:00',
                 launcher=SimpleLauncher(),
                 worker_init='''
-source /opt/conda_init.sh
-conda activate chiltepin 
 ''',
             ),
         )
@@ -37,40 +35,47 @@ conda activate chiltepin
 
 import os
 
+# Set FLUX_SSH
+os.environ["FLUX_SSH"] = "ssh"
+
+# Load the configuration
 parsl.load(config)
 
-remote = False
 shared_dir = './'
 
 chiltepin= '''
-    . /opt/conda_init.sh
-    conda activate chiltepin
+#    . /opt/conda_init.sh
+     conda activate chiltepin
 '''
 
 spack_stack='''
-    . /opt/jedi_init.sh
+#    . /opt/jedi_init.sh
+'''
+
+hercules_stack='''
+module load intel-oneapi-compilers/2023.1.0
+module load intel-oneapi-mpi/2021.7.1
+unset I_MPI_PMI_LIBRARY
+conda activate chiltepin
+export FLUX_SSH=/usr/bin/ssh
+export FLUX_PMI_LIBRARY_PATH=/home/charrop/miniforge3/envs/chiltepin/lib/flux/libpmi.so
 '''
 
 # Print out resources that Flux sees after it starts
 @bash_app
-def resource_list():
+def resource_list(stack=chiltepin):
     return '''
-    . /opt/conda_init.sh
-    conda activate chiltepin
+    {}
     flux resource list > parsl_flux_resource_list.txt
-    '''
+    '''.format(stack)
 
 # Test Flux PMI launch
 @bash_app
-def pmi_barrier(parsl_resource_specification={}):
+def pmi_barrier(stack=chiltepin, parsl_resource_specification={}):
     return '''
-    . /opt/conda_init.sh
-    conda activate chiltepin
-    env | grep -i flux > parsl_flux_pmi_barrier.txt
-    env | grep -i pmi >> parsl_flux_pmi_barrier.txt
-    export FLUX_PMI_LIBRARY_PATH=/opt/miniconda3/envs/chiltepin/lib/flux/libpmi.so
-    flux pmi --method=libpmi:$FLUX_PMI_LIBRARY_PATH barrier >> parsl_flux_pmi_barrier.txt
-    '''
+    {}
+    flux pmi barrier > parsl_flux_pmi_barrier.txt
+    '''.format(stack)
 
 # Compile the hello MPI program with GNU and OpenMPI
 @bash_app
@@ -78,7 +83,7 @@ def compile_app(dirpath, stdout=None, stderr=None, stack=chiltepin, parsl_resour
     return '''
     {}
     cd {}
-    mpif90 -o mpi_hello.exe mpi_hello.f90
+    mpiifort -fc=ifx -o mpi_hello.exe mpi_hello.f90
     '''.format(stack,dirpath)
 
 # Run the hello MPI program with GNU and OpenMPI
@@ -86,49 +91,50 @@ def compile_app(dirpath, stdout=None, stderr=None, stack=chiltepin, parsl_resour
 def mpi_hello(dirpath, stdout=None, stderr=None, stack=chiltepin, parsl_resource_specification={}):
     return '''
     {}
-    export FLUX_PMI_LIBRARY_PATH=/opt/miniconda3/envs/chiltepin/lib/flux/libpmi.so
     cd {}
     ./mpi_hello.exe
     '''.format(stack, dirpath)
 
 # Check the Flux resource list
-r = resource_list().result()
+r = resource_list(stack=hercules_stack).result()
 
 # Check the Flux pmi status
-p = pmi_barrier(parsl_resource_specification={"num_tasks": 6, "num_nodes": 3}).result()
+p = pmi_barrier(stack=hercules_stack, parsl_resource_specification={"num_tasks": 6, "num_nodes": 3}).result()
 
 # complile the app with chiltepin stack and wait for it to complete (.result())
 compile_app(dirpath=shared_dir,
             stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.out"),
             stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.err"),
-            stack=chiltepin,
+#            stack=chiltepin,
+            stack=hercules_stack,
            ).result()
 
 # run the mpi app with chiltepin stack
 hello = mpi_hello(dirpath=shared_dir,
                   stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.out"),
                   stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.err",),
-                  stack=chiltepin,
+#                  stack=chiltepin,
+                  stack=hercules_stack,
                   parsl_resource_specification={"num_tasks": 6, "num_nodes": 3})
 
 # Wait for the MPI app with chiltepin stack to finish
 hello.result()
 
-# complile the app with spack-stack stack and wait for it to complete (.result())
-compile_app(dirpath=shared_dir,
-            stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.out"),
-            stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.err"),
-            stack=spack_stack,
-           ).result()
-
-# run the mpi app with spack-stack stack
-hello = mpi_hello(dirpath=shared_dir,
-                  stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.out"),
-                  stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.err",),
-                  stack=spack_stack,
-                  parsl_resource_specification={"num_tasks": 6, "num_nodes": 3})
-
+## complile the app with spack-stack stack and wait for it to complete (.result())
+#compile_app(dirpath=shared_dir,
+#            stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.out"),
+#            stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_compile.err"),
+#            stack=spack_stack,
+#           ).result()
+#
+## run the mpi app with spack-stack stack
+#hello = mpi_hello(dirpath=shared_dir,
+#                  stdout=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.out"),
+#                  stderr=os.path.join(shared_dir, "parsl_flux_mpi_hello_run.err",),
+#                  stack=spack_stack,
+#                  parsl_resource_specification={"num_tasks": 6, "num_nodes": 3})
+#
 # Wait for the MPI app with spack-stack stack to finish
-hello.result()
+#hello.result()
 
 parsl.clear()


### PR DESCRIPTION
This PR is the first step toward generalizing configuration of Chiltepin workflows.  This adds the capability to provide platform-specific information via a YAML file.  The YAML file is then processed by a configuration factory which returns both a Parsl Config object and a sequence of required platform-specific environment initialization.  This Parsl Config is then loaded and the environment initialization is passed to the individual apps as needed.  Running on a different platform only requires creation of a new YAML file with appropriate settings and no internal code should be necessary.

This is still very rudimentary and could use improvement, but is limited in scope to minimize the change set being evaluated for this udpate.