### PR TITLE
Add test to ensure concurrent MPI programs don't use overlapping resources

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -99,7 +99,7 @@ jobs:
         run: docker exec frontend bash -l -c "conda activate chiltepin ; cd work ; pip install -e ."
       -
         name: Run test suite
-        run: docker exec frontend bash -l -c "conda activate chiltepin ; cd work/tests ; pytest --assert=plain --config=chiltepin.yaml"
+        run: docker exec frontend bash -l -c "conda activate chiltepin ; cd work/tests ; pytest --assert=plain --config=ci.yaml"
       -
         name: Debug session
         if: ${{ failure() }}

--- a/src/chiltepin/config/factory.py
+++ b/src/chiltepin/config/factory.py
@@ -28,6 +28,7 @@ def config_factory(yaml_config={}):
                 launch_cmd=f'srun --mpi=pmi2 --tasks-per-node=1 -c{cores_per_node} ' + FluxExecutor.DEFAULT_LAUNCH_CMD,
                 provider=SlurmProvider(
                     channel=LocalChannel(),
+                    cores_per_node=cores_per_node,
                     nodes_per_block=3,
                     init_blocks=1,
                     partition=partition,

--- a/tests/ci.yaml
+++ b/tests/ci.yaml
@@ -1,5 +1,5 @@
 provider:
-  cores per node: 16
+  cores per node: 2 
   partition: "slurmpar"
   account: ""
 

--- a/tests/mpi_pi.f90
+++ b/tests/mpi_pi.f90
@@ -54,7 +54,9 @@ program calculatePi
 
   pi = 4.0 * nCircle / nSquare
 
-  write(*,"(A,A,A,A,A,A,A,F15.13)") "Host ", TRIM(hostname), " rank ", TRIM(ADJUSTL(rank)), " of ", TRIM(ADJUSTL(size)), " local approximaiton of pi = ", pi
+  write(*,"(A,A,A,A,A,A,A,F15.13)") "Host ", TRIM(hostname), " rank ", &
+          TRIM(ADJUSTL(rank)), " of ", TRIM(ADJUSTL(size)), &
+          " local approximation of pi = ", pi
 
   call MPI_Reduce(nCircle, sumCircle, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD, error)
   call MPI_Reduce(nSquare, sumSquare, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD, error)

--- a/tests/mpi_pi.f90
+++ b/tests/mpi_pi.f90
@@ -1,0 +1,74 @@
+program calculatePi
+
+  use mpi
+
+  integer*8, parameter :: nSamples = 1000000000
+
+  integer :: error
+  integer :: worldSize, worldRank, nameLen
+  character(len=MPI_MAX_PROCESSOR_NAME) :: hostname
+  character(len=6) :: rank
+  character(len=6) :: size
+  integer*8 :: i
+  integer*8 :: nCircle, nSquare, sumCircle, sumSquare
+  real*8    :: randX, randY, distance, pi
+  integer   :: timeValues(8)
+  
+  ! Initialize the MPI environment
+  call MPI_Init(error)
+
+  ! Get the number of processes
+  call MPI_Comm_size(MPI_COMM_WORLD, worldSize, error)
+  write(size,'(I6)') worldSize
+
+  ! Get the rank of the process
+  call MPI_Comm_rank(MPI_COMM_WORLD, worldRank, error)
+  write(rank,'(I6)') worldRank
+
+  ! Get the name of the processor
+  call MPI_Get_processor_name(hostname, nameLen, error)
+
+  if (worldRank == 0) then
+    call date_and_time(VALUES=timeValues)
+    write(*,"(A,I2,A,I2,A,I2.2)") "Start Time = ", timeValues(5), ":", timeValues(6), ":", timeValues(7)
+  end if
+
+  ! Initialize the random number seed
+  call random_seed()
+
+  nCircle = 0
+  nSquare = 0
+  pi = 0.0
+  do i=1, nSamples
+    call random_number(randX)
+    call random_number(randY)
+
+    distance = randX * randX + randY * randY
+
+    if (distance <= 1) then
+      nCircle = nCircle + 1
+    end if
+    nSquare = nSquare + 1
+
+  end do
+
+  pi = 4.0 * nCircle / nSquare
+
+  write(*,"(A,A,A,A,A,A,A,F15.13)") "Host ", TRIM(hostname), " rank ", TRIM(ADJUSTL(rank)), " of ", TRIM(ADJUSTL(size)), " local approximaiton of pi = ", pi
+
+  call MPI_Reduce(nCircle, sumCircle, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD, error)
+  call MPI_Reduce(nSquare, sumSquare, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD, error)
+
+  if (worldRank == 0) then
+    write(*,"(A,F15.13)") "Collective approximation of pi = ", 4.0 * sumCircle / sumSquare
+  end if
+
+  if (worldRank == 0) then
+    call date_and_time(VALUES=timeValues)
+    write(*,"(A,I2,A,I2,A,I2.2)") "End Time = ", timeValues(5), ":", timeValues(6), ":", timeValues(7)
+  end if
+
+  ! Finalize the MPI environment.
+  call MPI_Finalize(error)
+
+end program calculatePi


### PR DESCRIPTION
This adds a test that ensures MPI programs can run concurrently and do not share resources when doing so.  A `mpi_pi.f90` test program is introduced to assist as it provides a bit more computation for situations requiring a longer run time for testing purposes.  It also exercises MPI collectives so is a bit more rigorous than the "hello" MPI program.

NOTE: The config factory was updated to set the `cores_per_node` property of the Slurm Provider.  Also, the testing fixture needed some modifications because the new tests needs to know how many cores per node there are.  So it was modified to return a dict that allows accessing the configuration and not just the environment settings.