### PR TITLE
Add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ conda env create --name chiltepin --file chiltepin.yml
 ## Building and running Chiltepin container
 
 Chiltepin provides a Docker container environment for building and running Parsl and Chiltepin
-applications. It makes use of docker compose to build a mult-node Slurm cluster for use as a
+applications. It makes use of docker compose to build a multi-node Slurm cluster for use as a
 backend for running the applications.  This repository is mounted from the host into the container's
 chiltepin directory.
 
@@ -110,5 +110,5 @@ Once chiltepin has been installed with `pip`, the tests can be run with:
 pytest --assert=plain --config=<config.yaml>
 ```
 
-Where `<config.yaml>` is a configuration file specific to the test platform.  See the examples
-in `tests/chiltepin.yaml`, `tests/ci.yaml`, and `hercules.yaml` for examples.
+Where `<config.yaml>` is a configuration file specific to the test platform.  For examples,
+look in `tests/chiltepin.yaml`, `tests/ci.yaml`, and `hercules.yaml`.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,41 @@ cd docker/install
 conda env create --name chiltepin --file chiltepin.yml
 ```
 
+## Building and running Chiltepin container
+
+Chiltepin provides a Docker container environment for building and running Parsl and Chiltepin
+applications. It makes use of docker compose to build a mult-node Slurm cluster for use as a
+backend for running the applications.  This repository is mounted from the host into the container's
+chiltepin directory.
+
+To build the container:
+
+```
+cd docker
+docker compose -f docker-compose.yml up -d --build
+```
+
+To use the container after it is built and up, log in with a bash shell:
+
+```
+docker exec -it frontend bash -l
+```
+
+Once in the container, you can activate the chiltepin environment, install chiltepin in
+editable mode, and run the tests
+
+```
+conda activate chiltepin
+cd chiltepin
+pip install -e .
+cd tests
+pytest --assert=plain --config=chiltepin.yaml
+```
+
+NOTE: Depending on how many cores your machine has and how many you've allocated to Docker,
+you may need to modify the `cores per node` setting in the configuration yaml file to match
+your machine's specifications to get all tests to pass.
+
 # Running Parsl apps
 
 The Chiltepin conda environment must be activated to run Parsl Chiltepin applications

--- a/README.md
+++ b/README.md
@@ -25,3 +25,55 @@ This repository is a collection of tools and demonstrations used to explore
 and test various technologies for implementing exascale scientific workflows.
 This collection of resources is not intended for production use, and is for
 research purposes only.
+
+# Installation
+
+This software can be installed on Linux systems.  NOTE: MacOS is not supported
+because the Flux scheduler does not support MacOS.  It can be used, however,
+on Macs in a container.  See below for instructions for building and using
+the Docker container.
+
+## Install the Chiltepin conda environment
+
+You will need a conda (miniconda3, anaconda, conda-forge, etc) installation.
+If you do not have one, you can use the script included in the docker directory
+to install it:
+
+```
+cd docker/install
+./install_miniconda.sh <installation path>
+```
+
+The chiltepin conda environment can be installed using the environment
+configuration in the docker directory:
+
+```
+cd docker/install
+conda env create --name chiltepin --file chiltepin.yml
+```
+
+# Running Parsl apps
+
+The Chiltepin conda environment must be activated to run Parsl Chiltepin applications
+
+```
+conda activate chiltepin
+```
+
+# Running the test suite
+The test suite is run with `pytest` and requires an editable installation of the Chiltepin
+repository.  Before running the test suite:
+
+```
+cd <repository root>
+pip install -e .
+```
+
+Once chiltepin has been installed with `pip`, the tests can be run with:
+
+```
+pytest --assert=plain --config=<config.yaml>
+```
+
+Where `<config.yaml>` is a configuration file specific to the test platform.  See the examples
+in `tests/chiltepin.yaml`, `tests/ci.yaml`, and `hercules.yaml` for examples.


### PR DESCRIPTION
This PR adds a minimal amount of documentation to describe installation of the chiltepin conda container and how to build the container and use it to run the test suite.

Much more detailed documentation will be needed later.