### PR TITLE
Add Hera support and set versions of Parsl and Flux

### DIFF
--- a/docker/install/chiltepin.yml
+++ b/docker/install/chiltepin.yml
@@ -7,11 +7,11 @@ dependencies:
   - python
   - pytest=7.4.0
   - pip
-  - flux-core
-  - flux-sched
+  - flux-core=0.52.0
+  - flux-sched=0.28.0
   - openmpi
   - openmpi-mpicc
   - openmpi-mpicxx
   - openmpi-mpifort
   - pip:
-    - parsl[monitoring]
+    - parsl[monitoring]==2023.12.4

--- a/tests/hera.yaml
+++ b/tests/hera.yaml
@@ -1,0 +1,10 @@
+provider:
+  cores per node: 40
+  partition: "hera"
+  account: "gsd-hpcs"
+
+environment:
+  - "module load intel/2022.3.0"
+  - "module load impi/2022.3.0"
+  - "unset I_MPI_PMI_LIBRARY"
+  - "export CHILTEPIN_MPIF90='mpiifort -fc=ifx'"


### PR DESCRIPTION
This PR adds explicit support for Hera.  A `hera.yaml` config file is added.  Also, it was discovered that the latest Parsl breaks the latest version of Flux that is available via conda.  So we also explicitly set the version of Parsl to the latest one that is compatible with the latest available version of Flux.