### PR TITLE
Add test to test_mpi_hello to validate run output 

### DIFF
--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -123,6 +123,12 @@ def test_run_mpi_hello(load_config):
                           ).result()
     assert hello == 0
 
+    with open('parsl_flux_mpi_hello_run.out', 'r') as f:
+        print("file", f.read())
+        for line in f:
+            assert re.match(r'ƒ\S+: Hello world from host -\S+, rank \d+ out of 6.', f.read())
+
+
 def test_compile_mpi_pi(load_config):
     shared_dir = "./"
     c = compile_mpi_pi(dirpath=shared_dir,

--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -124,9 +124,8 @@ def test_run_mpi_hello(load_config):
     assert hello == 0
 
     with open('parsl_flux_mpi_hello_run.out', 'r') as f:
-        print("file", f.read())
         for line in f:
-            assert re.match(r'ƒ\S+: Hello world from host -\S+, rank \d+ out of 6.', f.read())
+            assert re.match(r'Hello world from host \S+, rank \d+ out of 6', line)
 
 
 def test_compile_mpi_pi(load_config):


### PR DESCRIPTION
The `test_mpi_hello` test in `tests/test_parsl_flux_mpi_hello.py` only checks that the Parsl App completed with a status of 0 (meaning success). It does not actually check whether the output of the task, written to `parsl_flux_mpi_hello_run.out` is correct. This test needs to be updated to validate the output.

Closes Issue #44 