### PR TITLE
Add test to test_mpi_hello to validate run output

### DIFF
--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -122,6 +122,9 @@ def test_run_mpi_hello(load_config):
                           parsl_resource_specification={"num_tasks": 6, "num_nodes": 3},
                           ).result()
     assert hello == 0
+    with open('parsl_flux_mpi_hello_run.out', 'r') as f:
+        for line in f:
+            assert re.match(r'Hello world from host \S+, rank \d+ out of 6', line)
 
 def test_compile_mpi_pi(load_config):
     shared_dir = "./"


### PR DESCRIPTION
The `test_mpi_hello` test in `tests/test_parsl_flux_mpi_hello.py` only checks that the Parsl App completed with a status of 0 (meaning success). It does not actually check whether the output of the task, written to `parsl_flux_mpi_hello_run.out` is correct. This test needs to be updated to validate the output.

Closes Issue #44 