### PR TITLE
Updated .gitignore including acending lexicographical ordering.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
 # Ignore Emacs backup files
-*~
 *#
+*~
 
 # Ignore Python artifacts
-__pycache__
 *.egg-info
+__pycache__
+
+# Ignore test output
+*.swp
+runinfo/
+tests/*.err
+tests/*.exe
+tests/*.out
+tests/core.*
+tests/flux_*
+tests/runinfo


### PR DESCRIPTION
Update `.gitignore` to disregard test output from stderr, stdout and others.

Also updated the sorting of the items listed in the `.gitignore`. They know follow an ascending lexicographical order. 