### PR TITLE
Add capability to use AWS S3 bucket as a spack binary cache

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 720
     permissions:
       packages: write
+      contents: read
     steps:
       -
         name: Checkout repository

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -38,8 +38,8 @@ jobs:
       -
         name: Create spack-stack Dockerfile and mirror
         run: |
-          export GITHUB_USER=${{ github.actor }}
-          export GITHUB_TOKEN=${{ secrets.GHCR_TOKEN }}
+          export S3_BUILD_CACHE_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_KEY.actor }}
+          export S3_BUILD_CACHE_SECRET_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -39,7 +39,7 @@ jobs:
         name: Create spack-stack Dockerfile and mirror
         run: |
           export GITHUB_USER=${{ github.actor }}
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          export GITHUB_TOKEN=${{ secrets.GHCR_TOKEN }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu2204-16c-64g-600ssd
     timeout-minutes: 720
     permissions:
       packages: write

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -11,6 +11,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     timeout-minutes: 720
+    permissions:
+      packages: write
     steps:
       -
         name: Checkout repository

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu2204-16c-64g-600ssd
+    runs-on: ubuntu-latest
     timeout-minutes: 720
     permissions:
       packages: write

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -32,9 +32,12 @@ jobs:
           docker image prune -a -f
           docker images
       -
-        name: Create spack-stack Dockerfile
+        name: Create spack-stack Dockerfile and mirror
         run: |
+          export GITHUB_USER=${{ github.actor }}
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cd docker/spack-stack
+          cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh
       -
         name: Build spack-stack
@@ -42,6 +45,7 @@ jobs:
         with:
           context: ./docker
           file: ./docker/spack-stack/Dockerfile
+          secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           push: true
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi:cache

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -23,11 +23,12 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
       -
         name: Prune pre-loaded GHA docker images
         run: |

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -38,7 +38,7 @@ jobs:
       -
         name: Create spack-stack Dockerfile and mirror
         run: |
-          export S3_BUILD_CACHE_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_KEY.actor }}
+          export S3_BUILD_CACHE_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}
           export S3_BUILD_CACHE_SECRET_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -18,3 +18,14 @@ spack containerize > ../../../Dockerfile
 # Remove unneeded spack-stack install
 popd
 rm -rf spack-stack
+
+# Modify the Dockerfile to use buildcache mirror at our ghcr
+perl -p -i -e 's:cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y:foobar:g' Dockerfile
+perl -p -i -e 's:foobar:foobar1 \\\n&&  foobar2 \\\n&&  foobar3 \\\n&&  foobar4 \\\n&&  foobar5 \\\n&&  foobar6 \\\n&&  foobar7\n:g' Dockerfile
+perl -p -i -e 's:foobar1:--mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml:g' Dockerfile
+perl -p -i -e 's:foobar2:cd /opt/spack-environment:s' Dockerfile
+perl -p -i -e 's:foobar3:\. \$SPACK_ROOT/share/spack/setup-env.sh:s' Dockerfile
+perl -p -i -e 's:foobar4:spack env activate \.:s' Dockerfile
+perl -p -i -e 's:foobar5:spack install --fail-fast --no-check-signature:s' Dockerfile
+perl -p -i -e 's:foobar6:spack buildcache push --unsigned ghcr_registry:s' Dockerfile
+perl -p -i -e 's:foobar7:spack gc -y:s' Dockerfile

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -21,7 +21,7 @@ rm -rf spack-stack
 
 # Modify the Dockerfile to use buildcache mirror at our ghcr
 perl -p -i -e 's:cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y:foobar:g' Dockerfile
-perl -p -i -e 's:foobar:foobar1 \\\n&&  foobar2 \\\n&&  foobar3 \\\n&&  foobar4 \\\n&&  foobar5 \\\n&&  foobar6 \\\n&&  foobar7\n:g' Dockerfile
+perl -p -i -e 's:foobar:foobar1 \\\n    foobar2 \\\n&&  foobar3 \\\n&&  foobar4 \\\n&&  foobar5 \\\n&&  foobar6 \\\n&&  foobar7\n:g' Dockerfile
 perl -p -i -e 's:foobar1:--mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml:g' Dockerfile
 perl -p -i -e 's:foobar2:cd /opt/spack-environment:s' Dockerfile
 perl -p -i -e 's:foobar3:\. \$SPACK_ROOT/share/spack/setup-env.sh:s' Dockerfile

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -12,6 +12,9 @@ spack stack create ctr --container=docker-ubuntu-gcc-openmpi --specs=jedi-ci
 cd envs/docker-ubuntu-gcc-openmpi
 perl -p -i -e "s/variants: \+internal-hwloc \+two_level_namespace/variants: \+internal-hwloc \+two_level_namespace \~static/g" spack.yaml
 
+# Modify spack.yaml to increase parallelism
+perl -p -i -e "s/build_jobs: 2/build_jobs: 16/g" spack.yaml
+
 # Create the spack-stack Dockerfile
 spack containerize > ../../../Dockerfile
 

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -30,5 +30,5 @@ perl -p -i -e 's:foobar2:cd /opt/spack-environment:s' Dockerfile
 perl -p -i -e 's:foobar3:\. \$SPACK_ROOT/share/spack/setup-env.sh:s' Dockerfile
 perl -p -i -e 's:foobar4:spack env activate \.:s' Dockerfile
 perl -p -i -e 's:foobar5:spack install --fail-fast --no-check-signature:s' Dockerfile
-perl -p -i -e 's:foobar6:spack buildcache push --unsigned ghcr_registry:s' Dockerfile
+perl -p -i -e 's:foobar6:spack buildcache push --unsigned --update-index s3_spack_stack_buildcache:s' Dockerfile
 perl -p -i -e 's:foobar7:spack gc -y:s' Dockerfile

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,5 +1,5 @@
 mirrors:
-  s3_spack_stack_buildcache:
+  s3_spack_stack_buildcache_rw:
     url: s3://spack-stack-bulid-cache/ubuntu-x86
     access_pair:
       - $S3_BUILD_CACHE_KEY

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,6 +1,6 @@
 mirrors:
-  ghcr_registry:
-    url: oci://ghcr.io/v2/noaa-gsl/exascaleworkflowsandbox/spack-stack-build-cache-x86
+  s3_spack_stack_buildcache:
+    url: s3://spack-stack-bulid-cache/ubuntu-x86
     access_pair:
-      - $GITHUB_USER
-      - $GITHUB_TOKEN
+      - $S3_BUILD_CACHE_KEY
+      - $S3_BUILD_CACHE_SECRET_KEY

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,6 +1,3 @@
 mirrors:
   ghcr_registry:
     url: oci://ghcr.io/v2/noaa-gsl/exascaleworkflowsandbox/spack-stack-build-cache-x86
-    access_pair:
-      - $GITHUB_USER
-      - $GITHUB_TOKEN

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,0 +1,6 @@
+mirrors:
+  ghcr_registry:
+    url: oci://ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-build-cache-x86
+    access_pair:
+      - $GITHUB_USER
+      - $GITHUB_TOKEN

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,3 +1,6 @@
 mirrors:
   ghcr_registry:
     url: oci://ghcr.io/v2/noaa-gsl/exascaleworkflowsandbox/spack-stack-build-cache-x86
+    access_pair:
+      - $GITHUB_USER
+      - $GITHUB_TOKEN

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,6 +1,6 @@
 mirrors:
   ghcr_registry:
-    url: oci://ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-build-cache-x86
+    url: oci://ghcr.io/v2/noaa-gsl/exascaleworkflowsandbox/spack-stack-build-cache-x86
     access_pair:
       - $GITHUB_USER
       - $GITHUB_TOKEN


### PR DESCRIPTION
This PR adds modifications to the spack-stack Dockerfile creation script and the CI workflow definition that allow pushing of spack binaries to a binary build cache stored an AWS S3 bucket.  This relies on a completed build in order for binaries to be pushed to the cache.  However, once they are there, it will speed building of spack-stack container by orders of magnitude.  The modifications add a template that can be used in conjunction with github secrets to configure the mirror in the container at build time.  The CI and Dockerfile make use of the mirror for pushing packages and using it for retrieving ones already built.