### PR TITLE
Add test to test_flux_resource_list does not validate output

### DIFF
--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -88,10 +88,9 @@ def test_flux_resource_list(load_config):
 
     pattern = re.compile(
       r'(\s+)STATE(\s+)NNODES(\s+)NCORES(\s+)NGPUS(\s+)NODELIST\n'
-      r'(\s+)free(\s+)(\d+)(\s+)(\d+)(\s+)(0)(\s+)(\S+)\n'
+      r'(\s+)free(\s+)(3)(\s+)(\d+)(\s+)(0)(\s+)(\S+)\n'
       r'(\s+)allocated(\s+)(1)(\s+)(1)(\s+)(0)(\s+)(\S+)\n'
-      r'(\s+)down(\s+)(0)(\s+)(0)(\s+)(0)'
-      r'.*\n',
+      r'(\s+)down(\s+)(0)(\s+)(0)(\s+)(0)',
     re.DOTALL)
 
     with open("parsl_flux_resource_list.out", "r") as f:

--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -88,9 +88,9 @@ def test_flux_resource_list(load_config):
 
     pattern = re.compile(
       r'(\s+)STATE(\s+)NNODES(\s+)NCORES(\s+)NGPUS(\s+)NODELIST\n'
-      r'(\s+)free(\s+)(\d+)(\s+)(\d+)(\s+)(\d+)(\s+)(\S+)\n'
-      r'(\s+)allocated(\s+)(\d+)(\s+)(\d+)(\s+)(\d+)(\s+)(\S+)\n'
-      r'(\s+)down(\s+)(\d+)(\s+)(\d+)(\s+)(\d+)'
+      r'(\s+)free(\s+)(\d+)(\s+)(\d+)(\s+)(0)(\s+)(\S+)\n'
+      r'(\s+)allocated(\s+)(1)(\s+)(1)(\s+)(0)(\s+)(\S+)\n'
+      r'(\s+)down(\s+)(0)(\s+)(0)(\s+)(0)'
       r'.*\n',
     re.DOTALL)
 

--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -85,6 +85,10 @@ def test_flux_resource_list(load_config):
                       stderr=('parsl_flux_resource_list.err', 'w'),
                       env=load_config["environment"]).result()
     assert r == 0
+
+    pattern = re.compile(r'.*', re.DOTALL)
+    with open("parsl_flux_resource_list.out", "r") as f:
+        assert pattern.match(f.read())
     
 # Test Flux pmi barrier
 def test_flux_pmi(load_config):

--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -86,7 +86,14 @@ def test_flux_resource_list(load_config):
                       env=load_config["environment"]).result()
     assert r == 0
 
-    pattern = re.compile(r'.*', re.DOTALL)
+    pattern = re.compile(
+      r'(\s+)STATE(\s+)NNODES(\s+)NCORES(\s+)NGPUS(\s+)NODELIST\n'
+      r'(\s+)free(\s+)(\d+)(\s+)(\d+)(\s+)(\d+)(\s+)(\S+)\n'
+      r'(\s+)allocated(\s+)(\d+)(\s+)(\d+)(\s+)(\d+)(\s+)(\S+)\n'
+      r'(\s+)down(\s+)(\d+)(\s+)(\d+)(\s+)(\d+)'
+      r'.*\n',
+    re.DOTALL)
+
     with open("parsl_flux_resource_list.out", "r") as f:
         assert pattern.match(f.read())
     


### PR DESCRIPTION
The test_flux_resource_list test in `tests/test_parsl_flux_mpi_hello.py` only checks that the Parsl App completed with a status of 0 (meaning success). It does not actually check whether the output of the task, written to `parsl_flux_resource_list.out` is correct. This test needs to be updated to validate the output. 

Two things will vary from run to run: 
1. The number of `free nodes`
2. The `NODELIST`, host name that is used

Closes #43 