### PR TITLE
Add Flux to spack-stack & remove miniconda environment

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -107,10 +107,10 @@ jobs:
           docker exec frontend bash -l -c "mkdir -p work; cd work ; cp -r ../chiltepin/* ."
       -
         name: Install chiltepin package
-        run: docker exec frontend bash -l -c "conda activate chiltepin ; cd work ; pip install -e ."
+        run: docker exec frontend bash -l -c "cd work ; pip install -e ."
       -
         name: Run test suite
-        run: docker exec frontend bash -l -c "conda activate chiltepin ; cd work/tests ; pytest --assert=plain --config=ci.yaml"
+        run: docker exec frontend bash -l -c "cd work/tests ; pytest --assert=plain --config=ci.yaml"
       -
         name: Debug session
         if: ${{ failure() }}

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -50,6 +50,9 @@ jobs:
           context: ./docker
           file: ./docker/spack-stack/Dockerfile
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
+          secrets: |
+            "aws_access_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
+            "aws_secret_access_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
           push: true
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi:cache

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu2204-16c-64g-600ssd
     timeout-minutes: 720
     permissions:
       packages: write

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -51,8 +51,8 @@ jobs:
           file: ./docker/spack-stack/Dockerfile
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "aws_access_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
-            "aws_secret_access_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
+            "spack_stack_buildcache_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
+            "spack_stack_buildcache_secret_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
           push: true
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi:cache

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu2204-16c-64g-600ssd
+    runs-on: ubuntu-latest
     timeout-minutes: 720
     permissions:
       packages: write

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -44,23 +44,6 @@ COPY --from=JEDI /opt/view /opt/view
 COPY --from=JEDI /opt/views /opt/views
 COPY --from=JEDI /opt/spack-environment /opt/spack-environment
 
-# Copy conda and jedi init scripts
-COPY ./install/jedi_init.sh /opt/jedi_init.sh
-COPY ./install/conda_init.sh /tmp/conda_init.sh
-
-# Copy conda install scripts
-COPY ./install/install_miniconda.sh /tmp/install_miniconda.sh
-COPY ./install/chiltepin.yml /tmp/chiltepin.yml
-
-RUN mkdir -p /opt/admin \
- && chown admin:admin /opt/admin
-
-USER admin
-
-# Install Miniconda3 and chiltepin environment
-RUN cd /tmp \
- && ./install_miniconda.sh /opt/admin/miniconda3 \
- && . /tmp/conda_init.sh \
- && conda env create --name chiltepin --file chiltepin.yml \
- && conda clean -afy \
- && cat /tmp/conda_init.sh >> /home/admin/.bash_profile
+# Set up spack-stack environment
+RUN echo ". /opt/spack-environment/activate.sh" >> /home/admin/.bashrc \
+ && echo ". /opt/spack-environment/activate.sh" >> /home/admin/.bash_profile

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get -yqq update && apt-get -yqq upgrade && apt-get -yqq install \
     wget \
  && rm -rf /var/lib/apt/lists/*
 
-COPY ./install/conda_init.sh /tmp/conda_init.sh
-
-RUN cat /tmp/conda_init.sh >> /home/admin/.bashrc \
- && cat /tmp/conda_init.sh >> /home/admin/.bash_profile
+# Set up spack-stack environment
+RUN echo ". /opt/spack-environment/activate.sh" >> /home/admin/.bashrc \
+ && echo ". /opt/spack-environment/activate.sh" >> /home/admin/.bash_profile

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get -yqq update && apt-get -yqq upgrade && apt-get -yqq install \
     wget \
  && rm -rf /var/lib/apt/lists/*
 
-COPY ./install/conda_init.sh /tmp/conda_init.sh
-
-RUN cat /tmp/conda_init.sh >> /home/admin/.bashrc \
- && cat /tmp/conda_init.sh >> /home/admin/.bash_profile
+# Set up spack-stack environment
+RUN echo ". /opt/spack-environment/activate.sh" >> /home/admin/.bashrc \
+ && echo ". /opt/spack-environment/activate.sh" >> /home/admin/.bash_profile

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -13,7 +13,30 @@ cd envs/docker-ubuntu-gcc-openmpi
 perl -p -i -e "s/variants: \+internal-hwloc \+two_level_namespace/variants: \+internal-hwloc \+two_level_namespace \~static/g" spack.yaml
 
 # Modify spack.yaml to increase parallelism
-perl -p -i -e "s/build_jobs: 2/build_jobs: 16/g" spack.yaml
+perl -p -i -e "s/build_jobs: 2/build_jobs: 8/g" spack.yaml
+
+# Modify spack.yaml to add flux-core and flux-sched
+perl -p -i -e "s/fms:/flux-core:\n      version: [0.53.0]\n    fms:/g" spack.yaml
+perl -p -i -e "s/fms:/flux-sched:\n      version: [0.28.0]\n    fms:/g" spack.yaml
+perl -p -i -e "s/fms\@/flux-core\@0.53.0\n  - fms\@/g" spack.yaml
+perl -p -i -e "s/fms\@/flux-sched\@0.28.0\n  - fms\@/g" spack.yaml
+
+# Modify spack.yaml to adjust boost variants for flux compatibility
+export boost_variants=$(
+cat<<'BOOST_EOF'
+      variants: ~atomic +chrono ~clanglibcpp +container ~context ~contract ~coroutine +date_time
+        ~debug +exception ~fiber +filesystem +graph ~graph_parallel ~icu ~iostreams ~json
+        ~locale ~log ~math ~mpi +multithreaded ~nowide ~numpy +pic +program_options +python
+        ~random +regex +serialization +shared ~signals ~singlethreaded ~stacktrace +system
+        ~taggedlayout +test +thread +timer ~type_erasure ~versionedlayout ~wave cxxstd=17
+        visibility=hidden
+BOOST_EOF
+)
+perl -i -p0e 's/      variants\:.*visibility=hidden/$ENV{boost_variants}/s' spack.yaml
+
+# Modify spack.yaml to install py-pytest
+perl -p -i -e "s/# To avoid/py-pytest:\n      require: ['\@7.3.2']\n    # To avoid/g" spack.yaml
+perl -p -i -e "s/py-pyyaml\@6.0/py-pytest\@7.3.2\n  - py-pyyaml\@6.0/g" spack.yaml
 
 # Create the spack-stack Dockerfile
 spack containerize > ../../../Dockerfile
@@ -30,8 +53,9 @@ RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml <<EO
   cd /opt/spack-environment
   . $SPACK_ROOT/share/spack/setup-env.sh
   spack env activate .
-  spack mirror add --s3-access-key-id "" --s3-access-key-secret "" s3_spack_stack_buildcache_ro s3://spack-stack-bulid-cache/ubuntu-x86
+  spack mirror add --s3-access-key-id "" --s3-access-key-secret "" s3_spack_stack_buildcache_ro s3://chiltepin/spack-stack/
   spack install --fail-fast --no-check-signature
+  python -m pip install parsl[monitoring]==2023.12.4
   spack mirror list
   if [ "$(spack mirror list | wc -l)" = "3" ]; then
     spack buildcache push --unsigned --update-index s3_spack_stack_buildcache_rw

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,6 +1,6 @@
 mirrors:
   s3_spack_stack_buildcache_rw:
-    url: s3://spack-stack-bulid-cache/ubuntu-x86
+    url: s3://chiltepin/spack-stack/
     access_pair:
       - $S3_BUILD_CACHE_KEY
       - $S3_BUILD_CACHE_SECRET_KEY

--- a/tests/chiltepin.yaml
+++ b/tests/chiltepin.yaml
@@ -4,6 +4,6 @@ provider:
   account: ""
 
 environment:
-  - "export FLUX_PMI_LIBRARY_PATH=/opt/admin/miniconda3/envs/chiltepin/lib/flux/libpmi.so"
+  - "export FLUX_PMI_LIBRARY_PATH=/opt/views/._view/lfvnahtxguhhjzbyvbk3ozvij43h244n/lib/flux/libpmi.so"
   - "export OMPI_MCA_btl=self,tcp"
   - "export CHILTEPIN_MPIF90=mpif90"

--- a/tests/ci.yaml
+++ b/tests/ci.yaml
@@ -4,6 +4,6 @@ provider:
   account: ""
 
 environment:
-  - "export FLUX_PMI_LIBRARY_PATH=/opt/admin/miniconda3/envs/chiltepin/lib/flux/libpmi.so"
+  - "export FLUX_PMI_LIBRARY_PATH=/opt/views/._view/lfvnahtxguhhjzbyvbk3ozvij43h244n/lib/flux/libpmi.so"
   - "export OMPI_MCA_btl=self,tcp"
   - "export CHILTEPIN_MPIF90=mpif90"


### PR DESCRIPTION
This PR adds flux and pytest to the spack-stack environment and replaces the conda environment.  It also changes the build cache S3 bucket to one more appropriately (and spelled correctly) named.  Additionally, since the AWS CLI package is one of the packages installed in spack-stack, some additional Dockerfile secrets were needed to get the S3 authentication to work properly (for some reason the `access_pair` in the mirror config wasn't quite enough).

For now, the conda environment is only removed for the container build/tests.  A future PR will address the replacement of conda on HPCs and other non-container systems.