### PR TITLE
Remove old test output baselines that are no longer needed

### DIFF
--- a/tests/output/parsl_flux_mpi_hello_run.out.baseline
+++ b/tests/output/parsl_flux_mpi_hello_run.out.baseline
@@ -1,6 +1,0 @@
-Hello world from host slurmnode1, rank 0 out of 6
-Hello world from host slurmnode1, rank 1 out of 6
-Hello world from host slurmnode2, rank 2 out of 6
-Hello world from host slurmnode2, rank 3 out of 6
-Hello world from host slurmnode3, rank 4 out of 6
-Hello world from host slurmnode3, rank 5 out of 6

--- a/tests/output/parsl_flux_resource_list.txt.baseline
+++ b/tests/output/parsl_flux_resource_list.txt.baseline
@@ -1,4 +1,0 @@
-     STATE NNODES   NCORES    NGPUS NODELIST
-      free      3        5        0 slurmnode[1-3]
- allocated      1        1        0 slurmnode3
-      down      0        0        0 


### PR DESCRIPTION
This PR simply removes some old files that are no longer needed now that we have proper pytest functionality.