### PR TITLE
Fix spack-stack container build prep for spack-stack compatibility

### DIFF
--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -40,6 +40,7 @@ perl -p -i -e "s/py-pyyaml\@6.0/py-pytest\@7.3.2\n  - py-pyyaml\@6.0/g" spack.ya
 
 # Create the spack-stack Dockerfile
 spack containerize > ../../../Dockerfile
+mv spack-ext-* ../../../  # This is needed for a COPY into the container at build time
 
 # Remove unneeded spack-stack install
 popd


### PR DESCRIPTION
The spack-stack develop branch has recently modified the generation of Dockerfiles such that a COPY is made to bring code from the host machine into the container at build time. This update moves that code to the directory where we want to build the container so that the container build can take place in the `docker/spack-stack` directory instead of deep inside the `spack-stack` source that gets cloned during Dockerfile generation.