### PR TITLE
Add GitHub workflow to remove untagged container packages

### DIFF
--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -1,0 +1,80 @@
+name: ExascaleSandboxTests
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    branches: [ develop, main ]
+  workflow_dispatch:
+
+jobs:
+  cleanup-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/frontend
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/frontend'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/master
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/master'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/node
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/node'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      -
+        name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
+        uses: actions/delete-package-versions@v4
+        with: 
+          package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -20,7 +20,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -28,7 +28,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -36,7 +36,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -44,7 +44,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -52,7 +52,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -60,7 +60,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -68,7 +68,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -76,5 +76,5 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'


### PR DESCRIPTION
The repository is accumulating very large numbers of untagged packages when the CI runs.  This adds a CI workflow that removes untagged packages to keep the repository packages cleaned up.  Closes #68 .  