### PR TITLE
Fix volume race condition

### DIFF
--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -20,7 +20,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -28,7 +32,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -36,7 +44,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -44,7 +56,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -52,7 +68,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -60,7 +80,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -68,7 +92,11 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -76,5 +104,9 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
+<<<<<<< HEAD
           min-versions-to-keep: 0
+=======
+          min-versions-to-keep: 1
+>>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
           delete-only-untagged-versions: 'true'

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -20,15 +20,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -36,15 +28,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -52,15 +36,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -68,15 +44,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -84,15 +52,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -100,15 +60,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -116,15 +68,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -132,13 +76,5 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
-<<<<<<< HEAD
-<<<<<<< HEAD
           min-versions-to-keep: 0
-=======
-          min-versions-to-keep: 1
->>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
-=======
-          min-versions-to-keep: 0
->>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -21,10 +21,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -33,10 +37,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -45,10 +53,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -57,10 +69,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -69,10 +85,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -81,10 +101,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -93,10 +117,14 @@ jobs:
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -105,8 +133,12 @@ jobs:
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
 <<<<<<< HEAD
+<<<<<<< HEAD
           min-versions-to-keep: 0
 =======
           min-versions-to-keep: 1
 >>>>>>> 8d44464 (Add GitHub workflow to remove untagged container packages)
+=======
+          min-versions-to-keep: 0
+>>>>>>> ac88847 (Don't keep any untagged package versions)
           delete-only-untagged-versions: 'true'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         hostname: slurmmaster
         user: admin
         volumes:
-                - shared-vol:/home/admin
+                - shared-vol:/home/admin:nocopy
                 - opt-vol:/opt:ro
                 - ..:/home/admin/chiltepin
         environment:
@@ -41,7 +41,7 @@ services:
         hostname: slurmnode1
         user: admin
         volumes:
-                - shared-vol:/home/admin
+                - shared-vol:/home/admin:nocopy
                 - opt-vol:/opt:ro
                 - ..:/home/admin/chiltepin
         environment:
@@ -58,7 +58,7 @@ services:
         hostname: slurmnode2
         user: admin
         volumes:
-                - shared-vol:/home/admin
+                - shared-vol:/home/admin:nocopy
                 - opt-vol:/opt:ro
                 - ..:/home/admin/chiltepin
         environment:
@@ -75,7 +75,7 @@ services:
         hostname: slurmnode3
         user: admin
         volumes:
-                - shared-vol:/home/admin
+                - shared-vol:/home/admin:nocopy
                 - opt-vol:/opt:ro
                 - ..:/home/admin/chiltepin
         environment:


### PR DESCRIPTION
This PR uses the `nocopy` attribute for shared mounts in docker compose to remove the race condition caused by multiple containers trying to populate `/home` at startup time.  This change sets the `frontend` container to be the one to write to the volume, and the other containers do not attempt to update `/home` at startup.  This works because the initial contents of `/home` are the same on all containers.  Closes #70 