### PR TITLE
Need Python utility / library to sort imports tool implementation

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -148,8 +148,9 @@ jobs:
       -
         name: Format Check
         run:  |
-          pip install black
+          pip install black isort
           black src tests --check --diff
+          isort src tests --check --diff
       -
         name: Docker meta
         id: meta

--- a/install/install.sh
+++ b/install/install.sh
@@ -40,6 +40,7 @@ spack install --fail-fast --no-check-signature
 # Install parsl and black
 python -m pip install parsl[monitoring]==2023.12.4
 python -m pip install pytest-black
+python -m pip install pytest-isort
 
 # Push the packages to the mirror
 if [ "$(spack mirror list | wc -l)" = "3" ]; then

--- a/src/chiltepin/config.py
+++ b/src/chiltepin/config.py
@@ -1,11 +1,11 @@
-from parsl.config import Config
+import os
+
+import yaml
 from parsl.channels import LocalChannel
-from parsl.providers import SlurmProvider
+from parsl.config import Config
 from parsl.executors import FluxExecutor, HighThroughputExecutor
 from parsl.launchers import SimpleLauncher
-
-import os
-import yaml
+from parsl.providers import SlurmProvider
 
 
 # Define function to parse yaml config

--- a/tests/test_parsl_flux_mpi_hello.py
+++ b/tests/test_parsl_flux_mpi_hello.py
@@ -1,9 +1,10 @@
 import os
-from datetime import datetime as dt
-import parsl
-from parsl.app.app import bash_app
-import pytest
 import re
+from datetime import datetime as dt
+
+import parsl
+import pytest
+from parsl.app.app import bash_app
 
 import chiltepin.config
 

--- a/tests/test_parsl_hello.py
+++ b/tests/test_parsl_hello.py
@@ -1,7 +1,7 @@
 import parsl
-from parsl.app.app import python_app, bash_app
-from parsl.configs.local_threads import config
 import pytest
+from parsl.app.app import bash_app, python_app
+from parsl.configs.local_threads import config
 
 
 # Define a "hello world" Python Parsl App


### PR DESCRIPTION
Currently, there is no standardized way to format the imports to ensure consistency.

The use of `isort`, a code formatting tool should be incorporated into the chiltepin environment, both for containers and for on-prem HPC systems so that users can conform to standardization for sorting imports alphabetically, and automatically separated into sections and by type before contributing to the repository.


The addition of `isort` should also handle any no changes that will be applied once the tool is added.
The `isort` tool will be added with the `Format Check` step in the CI to apply consistency, and since `black` and `isort` are compatible that can be added directly next to each other. 