### PR TITLE
Migrate S3 Spack build cache to us-east-2

### DIFF
--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -156,6 +156,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     steps:
       -
         name: Checkout repository

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -97,8 +97,9 @@ jobs:
       -
         name: Create spack-stack Dockerfile and mirror
         run: |
-          export S3_BUILD_CACHE_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}
-          export S3_BUILD_CACHE_SECRET_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}
+          export S3_BUILD_CACHE_KEY=${{ env.AWS_ACCESS_KEY_ID }}
+          export S3_BUILD_CACHE_SECRET_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+          export S3_BUILD_CACHE_TOKEN=${{ env.AWS_SESSION_TOKEN }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh
@@ -110,8 +111,9 @@ jobs:
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
-            "spack_stack_buildcache_secret_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
+            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
+            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:cache

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -107,6 +107,10 @@ jobs:
           context: ./docker/spack-stack
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
+          secrets: |
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:cache
@@ -120,6 +124,10 @@ jobs:
           file: ./docker/spack-stack/Dockerfile
           platforms: linux/arm64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
+          secrets: |
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache,mode=max
@@ -215,6 +223,10 @@ jobs:
           context: ./docker/spack-stack
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
+          secrets: |
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:cache
@@ -228,6 +240,10 @@ jobs:
           file: ./docker/spack-stack/Dockerfile
           platforms: linux/amd64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
+          secrets: |
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache,mode=max

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -107,10 +107,6 @@ jobs:
           context: ./docker/spack-stack
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
-          secrets: |
-            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
-            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:cache
@@ -124,10 +120,6 @@ jobs:
           file: ./docker/spack-stack/Dockerfile
           platforms: linux/arm64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
-          secrets: |
-            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
-            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache,mode=max
@@ -223,10 +215,6 @@ jobs:
           context: ./docker/spack-stack
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
-          secrets: |
-            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
-            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:cache
@@ -240,10 +228,6 @@ jobs:
           file: ./docker/spack-stack/Dockerfile
           platforms: linux/amd64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
-          secrets: |
-            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
-            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache,mode=max

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   REGISTRY_IMAGE: ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi
+  AWS_REGION: us-east-2
 
 jobs:
   build-spack-stack-arm64:
@@ -17,6 +18,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     steps:
       -
         # Beta ARM runners do not have Docker installed
@@ -77,6 +79,17 @@ jobs:
           docker images
           docker image prune -a -f
           docker images
+      -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
+          role-duration-seconds: 1800 # 30 minutes
+          role-session-name: chiltepin-github-actions
+      - name: Test authentication
+        run: |
+          aws sts get-caller-identity
       -
         name: Create spack-stack Dockerfile and mirror
         run: |

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -51,6 +51,18 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v4
       -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
+          role-duration-seconds: 1800 # 30 minutes
+          role-session-name: chiltepin-github-actions
+      -
+        name: Test authentication
+        run: |
+          aws sts get-caller-identity
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -79,17 +91,6 @@ jobs:
           docker images
           docker image prune -a -f
           docker images
-      -
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
-          role-duration-seconds: 1800 # 30 minutes
-          role-session-name: chiltepin-github-actions
-      - name: Test authentication
-        run: |
-          aws sts get-caller-identity
       -
         name: Create spack-stack Dockerfile and mirror
         run: |

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -97,9 +97,6 @@ jobs:
       -
         name: Create spack-stack Dockerfile and mirror
         run: |
-          export S3_BUILD_CACHE_KEY=${{ env.AWS_ACCESS_KEY_ID }}
-          export S3_BUILD_CACHE_SECRET_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
-          export S3_BUILD_CACHE_TOKEN=${{ env.AWS_SESSION_TOKEN }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh
@@ -111,9 +108,9 @@ jobs:
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
-            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:cache
@@ -128,9 +125,9 @@ jobs:
           platforms: linux/arm64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
-            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache,mode=max
@@ -216,9 +213,6 @@ jobs:
       -
         name: Create spack-stack Dockerfile and mirror
         run: |
-          export S3_BUILD_CACHE_KEY=${{ env.AWS_ACCESS_KEY_ID }}
-          export S3_BUILD_CACHE_SECRET_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
-          export S3_BUILD_CACHE_TOKEN=${{ env.AWS_SESSION_TOKEN }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh
@@ -230,9 +224,9 @@ jobs:
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
-            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:cache
@@ -247,9 +241,9 @@ jobs:
           platforms: linux/amd64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
-            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache,mode=max

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
-          role-duration-seconds: 1800 # 30 minutes
+          role-duration-seconds: 18000 # 5 hours
           role-session-name: chiltepin-github-actions
       -
         name: Test authentication
@@ -128,8 +128,9 @@ jobs:
           platforms: linux/arm64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
-            "spack_stack_buildcache_secret_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
+            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
+            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache,mode=max
@@ -159,6 +160,18 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
+          role-duration-seconds: 18000 # 5 hours
+          role-session-name: chiltepin-github-actions
+      -
+        name: Test authentication
+        run: |
+          aws sts get-caller-identity
       -
         name: Make lint
         run:  |
@@ -202,8 +215,9 @@ jobs:
       -
         name: Create spack-stack Dockerfile and mirror
         run: |
-          export S3_BUILD_CACHE_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}
-          export S3_BUILD_CACHE_SECRET_KEY=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}
+          export S3_BUILD_CACHE_KEY=${{ env.AWS_ACCESS_KEY_ID }}
+          export S3_BUILD_CACHE_SECRET_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+          export S3_BUILD_CACHE_TOKEN=${{ env.AWS_SESSION_TOKEN }}
           cd docker/spack-stack
           cat mirrors.in.yaml | envsubst > mirrors.yaml
           ./create_dockerfile.sh
@@ -215,8 +229,9 @@ jobs:
           file: ./docker/spack-stack/Dockerfile.flux-only
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
-            "spack_stack_buildcache_secret_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
+            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
+            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
           push: false
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:cache
@@ -231,8 +246,9 @@ jobs:
           platforms: linux/amd64
           secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
           secrets: |
-            "spack_stack_buildcache_key=${{ secrets.SPACK_STACK_BUILDCACHE_KEY }}"
-            "spack_stack_buildcache_secret_key=${{ secrets.SPACK_STACK_BUILDCACHE_SECRET_KEY }}"
+            "spack_stack_buildcache_key=${{ env.AWS_ACCESS_KEY_ID }}"
+            "spack_stack_buildcache_secret_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "spack_stack_buildcache_token=${{ env.AWS_SESSION_TOKEN }}"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64:cache,mode=max

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -12,7 +12,7 @@ env:
   AWS_REGION: us-east-2
 
 jobs:
-  build-spack-stack-arm64:
+  build-flux-cache-arm64:
     runs-on: LinuxARM64-4core-16G-150Gb
     timeout-minutes: 360
     permissions:
@@ -115,39 +115,8 @@ jobs:
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-arm64:cache,mode=max
-      -
-        name: Build spack-stack and push by digest
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: ./docker/spack-stack
-          file: ./docker/spack-stack/Dockerfile
-          platforms: linux/arm64
-          secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
-          secrets: |
-            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
-            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
-            "session_token=${{ env.AWS_SESSION_TOKEN }}"
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache
-          cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache,mode=max
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      -
-        name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      -
-        name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-linux-arm64
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
 
-  build-spack-stack-amd64:
+  build-flux-cache-amd64:
     runs-on: ubuntu2204-4c-16g-150ssd
     timeout-minutes: 360
     permissions:
@@ -231,6 +200,198 @@ jobs:
           tags: ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:latest
           cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:cache
           cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/flux-cache-amd64:cache,mode=max
+
+  build-spack-stack-arm64:
+    runs-on: LinuxARM64-4core-16G-150Gb
+    needs: build-flux-cache-arm64
+    timeout-minutes: 360
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    steps:
+      -
+        # Beta ARM runners do not have Docker installed
+        name: Install Docker
+        run: |
+           # Uninstall incompatible packages
+           for pkg in docker.io containerd runc; do sudo apt-get remove $pkg; done
+           # Add Docker's official GPG key:
+           sudo apt-get update
+           sudo apt-get install ca-certificates curl
+           sudo install -m 0755 -d /etc/apt/keyrings
+           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+           sudo chmod a+r /etc/apt/keyrings/docker.asc
+           # Add the repository to Apt sources:
+           echo \
+             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+             $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+           sudo apt-get update -y
+           # Install docker packages
+           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+           # Allow runner use to run docker without sudo
+           sudo usermod -aG docker $USER
+           sudo apt-get install acl
+           sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+      -
+        name: Test Docker Installation
+        run: docker run hello-world
+      -
+        name: Install AWS CLI
+        run: sudo apt install -y awscli
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
+          role-duration-seconds: 21600 # 6 hours
+          role-session-name: chiltepin-github-actions
+      -
+        name: Test authentication
+        run: |
+          aws sts get-caller-identity
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=raw,value=latest
+          flavor: |
+            latest=true
+            prefix=
+            suffix=
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+      -
+        name: Prune pre-loaded GHA docker images
+        run: |
+          docker images
+          docker image prune -a -f
+          docker images
+      -
+        name: Create spack-stack Dockerfile and mirror
+        run: |
+          cd docker/spack-stack
+          cat mirrors.in.yaml | envsubst > mirrors.yaml
+          ./create_dockerfile.sh
+      -
+        name: Build spack-stack and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/spack-stack
+          file: ./docker/spack-stack/Dockerfile
+          platforms: linux/arm64
+          secret-files: "mirrors=./docker/spack-stack/mirrors.yaml"
+          secrets: |
+            "access_key_id=${{ env.AWS_ACCESS_KEY_ID }}"
+            "secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}"
+            "session_token=${{ env.AWS_SESSION_TOKEN }}"
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache
+          cache-to: type=registry,ref=ghcr.io/noaa-gsl/exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64:cache,mode=max
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-linux-arm64
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-spack-stack-amd64:
+    runs-on: ubuntu2204-4c-16g-150ssd
+    needs: build-flux-cache-amd64
+    timeout-minutes: 360
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_GITHUB_ROLE }}
+          role-duration-seconds: 21600 # 6 hours
+          role-session-name: chiltepin-github-actions
+      -
+        name: Test authentication
+        run: |
+          aws sts get-caller-identity
+      -
+        name: Make lint
+        run:  |
+          pip install flake8
+          flake8 src tests
+      -
+        name: Format Check
+        run:  |
+          pip install black isort
+          black src tests --check --diff
+          isort src tests --check --diff
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=raw,value=latest
+          flavor: |
+            latest=true
+            prefix=
+            suffix=
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+      -
+        name: Prune pre-loaded GHA docker images
+        run: |
+          docker images
+          docker image prune -a -f
+          docker images
+      -
+        name: Create spack-stack Dockerfile and mirror
+        run: |
+          cd docker/spack-stack
+          cat mirrors.in.yaml | envsubst > mirrors.yaml
+          ./create_dockerfile.sh
       -
         name: Build spack-stack and push by digest
         id: build

--- a/.github/workflows/docker-slurm.yml
+++ b/.github/workflows/docker-slurm.yml
@@ -48,6 +48,9 @@ jobs:
         name: Test Docker Installation
         run: docker run hello-world
       -
+        name: Install AWS CLI
+        run: sudo apt install -y awscli
+      -
         name: Checkout repository
         uses: actions/checkout@v4
       -

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -59,7 +59,10 @@ perl -p -i -e 's|(    mkdir -p \$SPACK_ROOT/opt/spack)|    curl -L $ENV{spack_pa
 # Create spack build command patch
 export docker_patch=$(
 cat<<'END_HEREDOC'
-RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml <<EOF
+RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
+    --mount=type=secret,id=access_key_id \
+    --mount=type=secret,id=secret_access_key \
+    --mount=type=secret,id=session_token <<EOF
   set -e
   cd /opt/spack-environment
   . $SPACK_ROOT/share/spack/setup-env.sh

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -72,6 +72,9 @@ RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
   python -m pip install parsl[monitoring]==2023.12.4
   spack mirror list
   if [ "$(spack mirror list | wc -l)" = "3" ]; then
+    export AWS_ACCESS_KEY_ID=$(cat /run/secrets/access_key_id)
+    export AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/secret_access_key)
+    export AWS_SESSION_TOKEN=$(cat /run/secrets/session_token)
     spack buildcache push --unsigned --update-index s3_spack_stack_buildcache_rw
   fi
   spack gc -y

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -59,22 +59,16 @@ perl -p -i -e 's|(    mkdir -p \$SPACK_ROOT/opt/spack)|    curl -L $ENV{spack_pa
 # Create spack build command patch
 export docker_patch=$(
 cat<<'END_HEREDOC'
-RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
-    --mount=type=secret,id=access_key_id \
-    --mount=type=secret,id=secret_access_key \
-    --mount=type=secret,id=session_token <<EOF
+RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml <<EOF
   set -e
   cd /opt/spack-environment
   . $SPACK_ROOT/share/spack/setup-env.sh
   spack env activate .
-  spack mirror add --s3-access-key-id "" --s3-access-key-secret "" s3_spack_stack_buildcache_ro s3://chiltepin/spack-stack/
+  spack mirror add --s3-access-key-id "" --s3-access-key-secret "" s3_spack_stack_buildcache_ro s3://chiltepin-us-east-2/spack-stack/
   spack install --fail-fast --no-check-signature
   python -m pip install parsl[monitoring]==2023.12.4
   spack mirror list
   if [ "$(spack mirror list | wc -l)" = "3" ]; then
-    export AWS_ACCESS_KEY_ID=$(cat /run/secrets/access_key_id)
-    export AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/secret_access_key)
-    export AWS_SESSION_TOKEN=$(cat /run/secrets/session_token)
     spack buildcache push --unsigned --update-index s3_spack_stack_buildcache_rw
   fi
   spack gc -y

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -61,7 +61,8 @@ export docker_patch=$(
 cat<<'END_HEREDOC'
 RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
     --mount=type=secret,id=spack_stack_buildcache_key \
-    --mount=type=secret,id=spack_stack_buildcache_secret_key <<EOF
+    --mount=type=secret,id=spack_stack_buildcache_secret_key \
+    --mount=type=secret,id=spack_stack_buildcache_token <<EOF
   set -e
   cd /opt/spack-environment
   . $SPACK_ROOT/share/spack/setup-env.sh
@@ -73,6 +74,7 @@ RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
   if [ "$(spack mirror list | wc -l)" = "3" ]; then
     export AWS_ACCESS_KEY_ID=$(cat /run/secrets/spack_stack_buildcache_key)
     export AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/spack_stack_buildcache_secret_key)
+    export AWS_SESSION_TOKEN=$(cat /run/secrets/spack_stack_buildcache_token)
     spack buildcache push --unsigned --update-index s3_spack_stack_buildcache_rw
   fi
   spack gc -y

--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -60,9 +60,9 @@ perl -p -i -e 's|(    mkdir -p \$SPACK_ROOT/opt/spack)|    curl -L $ENV{spack_pa
 export docker_patch=$(
 cat<<'END_HEREDOC'
 RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
-    --mount=type=secret,id=spack_stack_buildcache_key \
-    --mount=type=secret,id=spack_stack_buildcache_secret_key \
-    --mount=type=secret,id=spack_stack_buildcache_token <<EOF
+    --mount=type=secret,id=access_key_id \
+    --mount=type=secret,id=secret_access_key \
+    --mount=type=secret,id=session_token <<EOF
   set -e
   cd /opt/spack-environment
   . $SPACK_ROOT/share/spack/setup-env.sh
@@ -72,9 +72,9 @@ RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
   python -m pip install parsl[monitoring]==2023.12.4
   spack mirror list
   if [ "$(spack mirror list | wc -l)" = "3" ]; then
-    export AWS_ACCESS_KEY_ID=$(cat /run/secrets/spack_stack_buildcache_key)
-    export AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/spack_stack_buildcache_secret_key)
-    export AWS_SESSION_TOKEN=$(cat /run/secrets/spack_stack_buildcache_token)
+    export AWS_ACCESS_KEY_ID=$(cat /run/secrets/access_key_id)
+    export AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/secret_access_key)
+    export AWS_SESSION_TOKEN=$(cat /run/secrets/session_token)
     spack buildcache push --unsigned --update-index s3_spack_stack_buildcache_rw
   fi
   spack gc -y

--- a/docker/spack-stack/get_sso_credentials.sh
+++ b/docker/spack-stack/get_sso_credentials.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+profile=$1
+aws configure export-credentials --format env --profile $profile > ./temporary_aws_credentials.sh
+source ./temporary_aws_credentials.sh
+rm -f ./temporary_aws_credentials.sh
+cat mirrors.in.yaml | envsubst > mirrors.yaml

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -1,6 +1,7 @@
 mirrors:
   s3_spack_stack_buildcache_rw:
-    url: s3://chiltepin/spack-stack/
+    url: s3://chiltepin-us-east-2/spack-stack/
     access_pair:
       - $S3_BUILD_CACHE_KEY
       - $S3_BUILD_CACHE_SECRET_KEY
+    access_token: $S3_BUILD_CACHE_TOKEN

--- a/docker/spack-stack/mirrors.in.yaml
+++ b/docker/spack-stack/mirrors.in.yaml
@@ -2,6 +2,6 @@ mirrors:
   s3_spack_stack_buildcache_rw:
     url: s3://chiltepin-us-east-2/spack-stack/
     access_pair:
-      - $S3_BUILD_CACHE_KEY
-      - $S3_BUILD_CACHE_SECRET_KEY
-    access_token: $S3_BUILD_CACHE_TOKEN
+      - $AWS_ACCESS_KEY_ID
+      - $AWS_SECRET_ACCESS_KEY
+    access_token: $AWS_SESSION_TOKEN

--- a/install/get_sso_credentials.sh
+++ b/install/get_sso_credentials.sh
@@ -1,0 +1,1 @@
+../docker/spack-stack/get_sso_credentials.sh


### PR DESCRIPTION
This PR updates the CI workflow with new AWS role-based authentication for use with a new S3 bucket in the us-east-2 AWS region.  It also updates the install scripts used for installation on on-prem HPC platforms to take into account the new mechanism for obtaining SSO AWS credentials.  Closes #77.

The CI workflow new uses the `configure-aws-credentials` github action to assume a role that is authorized to access AWS resources from github.  The temporary credentials are configured to last 6 hours, which is the maximum duration of a GitHub Actions CI job.  The action supplies the temporary keys and tokens needed for passing into the Docker builds for pushing to the Spack binary build cache on S3. Due to very slow push times to S3, the CI workflow was split into more jobs (which each have a 6 hour time limit) to allow for more time to complete the push step at the end of the spack-stack build.  Additionally, a more powerful runner is used to enable more parallelism in the `make` steps of the spack-stack builds.

No AWS credentials are needed to run the `./install.sh` script when installing on on-prem HPC systems.  However, if one wishes to populate the S3 binary build cache for a particular HPC system OS, SSO credentials are needed for the `push` step.  In order to set up those credentials, a user will need to run `aws configure` to create a profile and supply the AWS start URL and a few other things.  The user will be prompted to login with SSO credentials.  Once that is done, the profile is used to login using `aws sso login --profile $PROFILE`.  After SSO credentials are configured and the user logged in, if the user runs `./insall.sh $PROFILE`, it will add the read/write binary build cache as an additional mirror and will attempt to push after the build, populating the binary build cache for future use.