### PR TITLE
Force pyzmq==25.1.2 to be installed to overcome incompatibility issues

### DIFF
--- a/docker/spack-stack/create_dockerfile.sh
+++ b/docker/spack-stack/create_dockerfile.sh
@@ -75,8 +75,8 @@ RUN --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
   spack install --fail-fast --no-check-signature
   python -m pip install globus-compute-sdk
   python -m pip install globus-compute-endpoint
-  python -m pip uninstall -y dill
-  python -m pip install dill==0.3.8
+  python -m pip uninstall -y dill pyzmq
+  python -m pip install dill==0.3.8 pyzmq==25.1.2
   python -m pip install parsl[monitoring]==2024.3.4
   python -m pip install pytest-black
   python -m pip install pytest-isort

--- a/install/install.sh
+++ b/install/install.sh
@@ -49,8 +49,8 @@ spack install --fail-fast --no-check-signature --deprecated
 # Install parsl, black, and isort
 python -m pip install globus-compute-sdk
 python -m pip install globus-compute-endpoint
-python -m pip uninstall -y dill
-python -m pip install dill==0.3.8
+python -m pip uninstall -y dill pyzmq
+python -m pip install dill==0.3.8 pyzmq==25.1.2
 python -m pip install parsl[monitoring]==2024.3.4
 python -m pip install pytest-black
 python -m pip install pytest-isort


### PR DESCRIPTION
It was discovered that the version of `pyzmq` that `globus-compute-endpoint` wants to install is not compatible with the version of `libzmq` that is installed by Spack for `flux-sched`.  Running any Parsl program or the `globus-compute-endpoint` command result in an error:

```
ImportError: libzmq.so.5: cannot open shared object file: No such file or directory
```

This PR forces pip to install a newer version of `pyzmq` that works with the `libzmq` installed by Spack.  This does violate specified dependencies for `globus-compute-endpoint` but tests show no issues.

Closes #87 