### PR TITLE
Synchronize Python version with version used in spack-stack

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -35,7 +35,7 @@ fi
 spack mirror list
 
 # Add flux, pytest and flake8 to chiltepin spack environment
-spack add python
+spack add python@3.10.13
 spack add py-pip
 spack add py-pytest@7.3.2
 spack add flux-core@0.58.0


### PR DESCRIPTION
This PR pins the version of Python used in install/install.sh to match the version of Python used in spack-stack. This is important because the versions of tools needs to be consistent across Globus Compute endpoints. Closes https://github.com/NOAA-GSL/ExascaleWorkflowSandbox/issues/89