### PR TITLE
Leadtime utility functions renamed and unit tests added.

### DIFF
--- a/src/chiltepin/jedi/leadtime.py
+++ b/src/chiltepin/jedi/leadtime.py
@@ -1,0 +1,50 @@
+def leadtime_to_seconds(leadtime):
+    import re
+
+    seconds = 0
+    p = re.compile(r"\D+(\d+)S")
+    m = p.search(leadtime)
+    if m:
+        seconds += int(m.group(1))
+    p = re.compile(r"\D+(\d+)M")
+    m = p.search(leadtime)
+    if m:
+        seconds += int(m.group(1)) * 60
+    p = re.compile(r"\D+(\d+)H")
+    m = p.search(leadtime)
+    if m:
+        seconds += int(m.group(1)) * 3600
+    p = re.compile(r"\D+(\d+)D")
+    m = p.search(leadtime)
+    if m:
+        seconds += int(m.group(1)) * 3600 * 24
+    p = re.compile("M")
+    m = p.match(leadtime)
+    if m:
+        seconds = seconds * -1
+    return seconds
+
+
+def seconds_to_leadtime(s):
+    leadtime = ""
+    if s < 0:
+        leadtime = "M"
+        seconds = s * -1
+    else:
+        leadtime = "P"
+        seconds = s
+    days = seconds // (3600 * 24)
+    if days > 0:
+        leadtime = leadtime + f"{days}D"
+    if seconds % (3600 * 24) != 0 or seconds == 0:
+        leadtime = leadtime + "T"
+    hours = (seconds - days * 3600 * 24) // 3600
+    if hours > 0:
+        leadtime = leadtime + f"{hours}H"
+    minutes = (seconds - days * 3600 * 24 - hours * 3600) // 60
+    if minutes > 0:
+        leadtime = leadtime + f"{minutes}M"
+    seconds = seconds - days * 3600 * 24 - hours * 3600 - minutes * 60
+    if (days == 0 and hours == 0 and minutes == 0) or (seconds > 0):
+        leadtime = leadtime + f"{seconds}S"
+    return leadtime

--- a/tests/test_leadtime.py
+++ b/tests/test_leadtime.py
@@ -1,0 +1,41 @@
+from chiltepin.jedi.leadtime import leadtime_to_seconds, seconds_to_leadtime
+
+
+def test_leadtime_to_seconds():
+    assert leadtime_to_seconds("PT0S") == 0
+    assert leadtime_to_seconds("PT1M") == 60
+    assert leadtime_to_seconds("PT1H") == 3600
+    assert leadtime_to_seconds("PT1H30M") == 5400
+
+    assert leadtime_to_seconds("P1D") == 86400
+    assert leadtime_to_seconds("P1DT1H") == 90000
+    assert leadtime_to_seconds("P1DT1H30M") == 91800
+
+    assert leadtime_to_seconds("MT0S") == -0
+    assert leadtime_to_seconds("MT1M") == -60
+    assert leadtime_to_seconds("MT1H") == -3600
+    assert leadtime_to_seconds("MT1H30M") == -5400
+
+    assert leadtime_to_seconds("M1D") == -86400
+    assert leadtime_to_seconds("M1DT1H") == -90000
+    assert leadtime_to_seconds("M1DT1H30M") == -91800
+
+
+def test_seconds_to_leadtime():
+    assert seconds_to_leadtime(0) == "PT0S"
+    assert seconds_to_leadtime(60) == "PT1M"
+    assert seconds_to_leadtime(3600) == "PT1H"
+    assert seconds_to_leadtime(5400) == "PT1H30M"
+
+    assert seconds_to_leadtime(86400) == "P1D"
+    assert seconds_to_leadtime(90000) == "P1DT1H"
+    assert seconds_to_leadtime(91800) == "P1DT1H30M"
+
+    assert seconds_to_leadtime(-0) == "PT0S"
+    assert seconds_to_leadtime(-60) == "MT1M"
+    assert seconds_to_leadtime(-3600) == "MT1H"
+    assert seconds_to_leadtime(-5400) == "MT1H30M"
+
+    assert seconds_to_leadtime(-86400) == "M1D"
+    assert seconds_to_leadtime(-90000) == "M1DT1H"
+    assert seconds_to_leadtime(-91800) == "M1DT1H30M"


### PR DESCRIPTION
The `leadtime.fcst_to_seconds` and `leadtime.seconds_to_fcst` utility functions should be renamed to better reflect what they do. 

`leadtime.fcst_to_seconds` should be renamed to `leadtime.leadtime_to_seconds`.
`leadtime.seconds_to_fcst` should be renamed to `leadtime.seconds_to_leadtime`.

Added unit tests to the utility functions to ensure they work correctly. The tests cover the following scenarios:

"PT0S" <---> 0
"PT1M" <---> 60
"PT1H" <---> 3600
"PT1H30M" <---> 5400
"P1D" <---> 86400
"P1DT1H" <---> 90000
"P1DT1H30M" <---> 91800
"MT0S" <---> 0
"MT1M" <---> -60
"MT1H" <---> -3600
"MT1H30M" <--> -5400
"M1D" <--->  -86400
"M1DT1H" <---> -90000
"M1DT1H30M"<--->  -91800


closes #86 