### PR TITLE
Update to actions/delete-package-versions@v5

### DIFF
--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -1,4 +1,4 @@
-name: ExascaleSandboxTests
+name: PackageCleanup
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     steps:
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
@@ -24,7 +24,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
@@ -32,7 +32,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
@@ -40,7 +40,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
@@ -48,7 +48,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
@@ -56,7 +56,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
@@ -64,7 +64,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
@@ -72,7 +72,7 @@ jobs:
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -21,7 +21,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -30,7 +29,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -39,7 +37,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -48,7 +45,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -57,7 +53,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -66,7 +61,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -75,7 +69,6 @@ jobs:
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -84,5 +77,4 @@ jobs:
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
           min-versions-to-keep: 0
-          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -20,7 +20,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -28,7 +28,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -36,7 +36,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -44,7 +44,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -52,7 +52,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -60,7 +60,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -68,7 +68,7 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -76,5 +76,5 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           delete-only-untagged-versions: 'true'

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -20,7 +20,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/frontend
@@ -28,7 +29,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/frontend'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/master
@@ -36,7 +38,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/master'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/node
@@ -44,7 +47,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/node'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-amd64
@@ -52,7 +56,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-amd64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/flux-cache-arm64
@@ -60,7 +65,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/flux-cache-arm64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64
@@ -68,7 +74,8 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-amd64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'
       -
         name: Remove untagged versions of exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64
@@ -76,5 +83,6 @@ jobs:
         with: 
           package-name: 'exascaleworkflowsandbox/spack-stack-gnu-openmpi-cache-arm64'
           package-type: 'container'
-          min-versions-to-keep: 1
+          min-versions-to-keep: 0
+          num-old-versions-to-delete: 10
           delete-only-untagged-versions: 'true'


### PR DESCRIPTION
This PR simply updates the version of the `actions/delete-package-versions` action used in the CI workflow to version 5. Fixes #102.