### PR TITLE
Update Hera config for new spack-stack location

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -58,7 +58,7 @@ hera:
   
   environment:
     - "module purge"
-    - "module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core"
+    - "module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core"
     - "module load stack-intel/2021.5.0"
     - "module load stack-intel-oneapi-mpi/2021.5.1"
     - "module load stack-python/3.10.13"


### PR DESCRIPTION
This updates the Hera config file to reflect the new location of spack-stack after the Rocky8 transition was completed.