### PR TITLE
Update uwtools version

### DIFF
--- a/docker/spack-stack/Dockerfile.patch
+++ b/docker/spack-stack/Dockerfile.patch
@@ -149,7 +149,7 @@
 +  python -m pip install parsl[monitoring]==2024.6.3
 +  python -m pip install pytest-black
 +  python -m pip install pytest-isort
-+  python -m pip install 'uwtools @ git+https://github.com/ufs-community/uwtools@main#subdirectory=src'
++  python -m pip install 'uwtools @ git+https://github.com/ufs-community/uwtools@2.3.2#subdirectory=src'
 +  python -m pip install pytest
 +  spack mirror list
 +  if [ "$(spack mirror list | wc -l)" = "3" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ globus-compute-endpoint
 parsl[monitoring]>=2024.06.03
 dill==0.3.8
 jsonschema==4.22.*
-uwtools @ git+https://github.com/ufs-community/uwtools@v2.3.1#subdirectory=src
+uwtools @ git+https://github.com/ufs-community/uwtools@v2.3.2#subdirectory=src
 awscli
 
 # Add uwtools dependencies to ensure they


### PR DESCRIPTION
- A new bugfix release for uwtools has come out that addresses fixing leadtime logic when processing 0-hr forecast.