### PR TITLE
Remove parsl resource specification from QG wrappers

### DIFF
--- a/apps/mpas/bin/experiment.py
+++ b/apps/mpas/bin/experiment.py
@@ -164,6 +164,9 @@ def main(user_config_file: Path) -> None:
                 output_path=get_ics_dir,
             )
 
+            # Wait for the data to be retrieved
+            get_ics_data.result()
+
             # Get the lbcs data
             get_lbcs_data_config = experiment_config["get_lbcs_data"]
             get_lbcs_dir = Path(get_lbcs_data_config["run_dir"])
@@ -179,7 +182,6 @@ def main(user_config_file: Path) -> None:
             )
 
             # Wait for the data to be retrieved
-            get_ics_data.result()
             get_lbcs_data.result()
 
             # Run ungrib

--- a/src/chiltepin/jedi/qg/wrapper.py
+++ b/src/chiltepin/jedi/qg/wrapper.py
@@ -85,7 +85,6 @@ class QG:
             stderr=None,
             jobs=8,
             configure=None,
-            parsl_resource_specification={"num_nodes": 1},
         ):
             return self.environment + textwrap.dedent(
                 f"""
@@ -167,14 +166,12 @@ class QG:
         stdout=None,
         stderr=None,
         executors=["serial"],
-        parsl_resource_specification={"num_nodes": 1},
     ):
         return self.get_make_task(executors=executors)(
             configure=configure,
             jobs=jobs,
             stdout=stdout,
             stderr=stderr,
-            parsl_resource_specification=parsl_resource_specification,
         )
 
     def install(

--- a/src/chiltepin/metis/wrapper.py
+++ b/src/chiltepin/metis/wrapper.py
@@ -54,7 +54,6 @@ class Metis:
             stderr=None,
             jobs=8,
             clone=None,
-            parsl_resource_specification={"num_nodes": 1},
         ):
             return self.environment + textwrap.dedent(
                 f"""
@@ -149,7 +148,6 @@ class Metis:
             jobs=jobs,
             stdout=stdout,
             stderr=stderr,
-            parsl_resource_specification=parsl_resource_specification,
         )
 
     def install(

--- a/src/chiltepin/mpas/limited_area/wrapper.py
+++ b/src/chiltepin/mpas/limited_area/wrapper.py
@@ -68,7 +68,6 @@ class LimitedArea:
             region,
             stdout=None,
             stderr=None,
-            parsl_resource_specification={},
             install=None,
         ):
             resolution_cells = {

--- a/src/chiltepin/mpas/wrapper.py
+++ b/src/chiltepin/mpas/wrapper.py
@@ -51,7 +51,6 @@ class MPAS:
             stderr=None,
             jobs=8,
             clone=None,
-            parsl_resource_specification={"num_nodes": 1},
         ):
             repo_url = (
                 "https://raw.githubusercontent.com/NOAA-GSL/ExascaleWorkflowSandbox/"
@@ -206,14 +205,12 @@ class MPAS:
         stdout=None,
         stderr=None,
         executors=["service"],
-        parsl_resource_specification={"num_nodes": 1},
     ):
         return self.get_make_task(executors=executors)(
             clone=clone,
             jobs=jobs,
             stdout=stdout,
             stderr=stderr,
-            parsl_resource_specification=parsl_resource_specification,
         )
 
     def install(

--- a/src/chiltepin/wps/wrapper.py
+++ b/src/chiltepin/wps/wrapper.py
@@ -51,7 +51,6 @@ class WPS:
             WRF_dir=None,
             jobs=8,
             clone=None,
-            parsl_resource_specification={"num_nodes": 1},
         ):
             if WRF_dir is None:
                 no_wrf = "--nowrf"
@@ -175,7 +174,6 @@ class WPS:
         stdout=None,
         stderr=None,
         executors=["service"],
-        parsl_resource_specification={"num_nodes": 1},
     ):
         return self.get_make_task(executors=executors)(
             clone=clone,
@@ -183,7 +181,6 @@ class WPS:
             WRF_dir=WRF_dir,
             stdout=stdout,
             stderr=stderr,
-            parsl_resource_specification=parsl_resource_specification,
         )
 
     def install(


### PR DESCRIPTION
The new versions of Parsl have removed support for `parsl_resource_specification` from HTEX Executors so this PR removes it from the wrappers that use it.