### PR TITLE
Add Chiltepin task decorators

### DIFF
--- a/apps/mpas/bin/experiment.py
+++ b/apps/mpas/bin/experiment.py
@@ -82,6 +82,7 @@ def main(user_config_file: Path) -> None:
         install_limited_area = limited_area.install(
             stdout=experiment_path / "install_limited_area.out",
             stderr=experiment_path / "install_limited_area.err",
+            executor="service"
         )
 
         # Intall Metis
@@ -109,6 +110,7 @@ def main(user_config_file: Path) -> None:
             region="conus",
             stdout=experiment_path / "create_region.out",
             stderr=experiment_path / "create_region.err",
+            executor="service",
             install=install_limited_area,
         )
         create_region.result()
@@ -133,6 +135,7 @@ def main(user_config_file: Path) -> None:
                         nprocs,
                         stdout=experiment_path / f"gpmetis_{nprocs}.out",
                         stderr=experiment_path / f"gpmetis_{nprocs}.err",
+                        executor="compute",
                         install=install_metis,
                     )
                 )
@@ -190,6 +193,7 @@ def main(user_config_file: Path) -> None:
                 cycle_iso,
                 stdout=experiment_path / f"ungrib_{yyyymmddhh}.out",
                 stderr=experiment_path / f"ungrib_{yyyymmddhh}.err",
+                executor="compute",
                 install=install_wps,
             )
 
@@ -203,7 +207,13 @@ def main(user_config_file: Path) -> None:
                 "create_ics",
                 stdout=experiment_path / f"mpas_init_ics_{yyyymmddhh}.out",
                 stderr=experiment_path / f"mpas_init_ics_{yyyymmddhh}.err",
+                executor="mpi",
                 install=install_mpas,
+                parsl_resource_specification={
+                    "num_nodes": 1,
+                    "num_ranks": 4,
+                    "ranks_per_node": 4,
+                }
             )
 
             # Wait for initial conditions
@@ -216,7 +226,13 @@ def main(user_config_file: Path) -> None:
                 "create_lbcs",
                 stdout=experiment_path / f"mpas_init_lbcs_{yyyymmddhh}.out",
                 stderr=experiment_path / f"mpas_init_lbcs_{yyyymmddhh}.err",
+                executor="mpi",
                 install=install_mpas,
+                parsl_resource_specification={
+                    "num_nodes": 1,
+                    "num_ranks": 4,
+                    "ranks_per_node": 4,
+                }
             )
 
             # Wait for lateral boundary conditions
@@ -229,7 +245,13 @@ def main(user_config_file: Path) -> None:
                 "forecast",
                 stdout=experiment_path / f"mpas_forecast_{yyyymmddhh}.out",
                 stderr=experiment_path / f"mpas_forecast_{yyyymmddhh}.err",
+                executor="mpi",
                 install=install_mpas,
+                parsl_resource_specification={
+                    "num_nodes": 1,
+                    "num_ranks": 32,
+                    "ranks_per_node": 32,
+                }
             )
 
             # Wait for the forecast

--- a/apps/mpas/bin/experiment.py
+++ b/apps/mpas/bin/experiment.py
@@ -82,7 +82,7 @@ def main(user_config_file: Path) -> None:
         install_limited_area = limited_area.install(
             stdout=experiment_path / "install_limited_area.out",
             stderr=experiment_path / "install_limited_area.err",
-            executor="service"
+            executor="service",
         )
 
         # Intall Metis
@@ -213,7 +213,7 @@ def main(user_config_file: Path) -> None:
                     "num_nodes": 1,
                     "num_ranks": 4,
                     "ranks_per_node": 4,
-                }
+                },
             )
 
             # Wait for initial conditions
@@ -232,7 +232,7 @@ def main(user_config_file: Path) -> None:
                     "num_nodes": 1,
                     "num_ranks": 4,
                     "ranks_per_node": 4,
-                }
+                },
             )
 
             # Wait for lateral boundary conditions
@@ -251,7 +251,7 @@ def main(user_config_file: Path) -> None:
                     "num_nodes": 1,
                     "num_ranks": 32,
                     "ranks_per_node": 32,
-                }
+                },
             )
 
             # Wait for the forecast

--- a/src/chiltepin/jedi/qg/wrapper.py
+++ b/src/chiltepin/jedi/qg/wrapper.py
@@ -74,7 +74,15 @@ class QG:
         )
 
     @join_task
-    def install(self, jobs=8, stdout=None, stderr=None, clone_executor="service", configure_executor="service", make_executor="compute"):
+    def install(
+        self,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        clone_executor="service",
+        configure_executor="service",
+        make_executor="compute",
+    ):
         clone = self.clone(
             stdout=(stdout, "w"),
             stderr=(stderr, "w"),

--- a/src/chiltepin/jedi/qg/wrapper.py
+++ b/src/chiltepin/jedi/qg/wrapper.py
@@ -16,7 +16,11 @@ class QG:
         self.tag = tag
 
     @bash_task
-    def clone(self, stdout=None, stderr=None):
+    def clone(
+        self,
+        stdout=None,
+        stderr=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)
@@ -31,7 +35,12 @@ class QG:
         )
 
     @bash_task
-    def configure(self, stdout=None, stderr=None, clone=None):
+    def configure(
+        self,
+        stdout=None,
+        stderr=None,
+        clone=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)
@@ -59,7 +68,13 @@ class QG:
         )
 
     @bash_task
-    def make(self, jobs=8, stdout=None, stderr=None, configure=None):
+    def make(
+        self,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        configure=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)

--- a/src/chiltepin/metis/wrapper.py
+++ b/src/chiltepin/metis/wrapper.py
@@ -2,6 +2,7 @@ import textwrap
 
 from chiltepin.tasks import bash_task, join_task
 
+
 class Metis:
 
     def __init__(
@@ -14,9 +15,12 @@ class Metis:
         self.install_path = install_path
         self.tag = tag
 
-
     @bash_task
-    def clone(self, stdout=None, stderr=None):
+    def clone(
+        self,
+        stdout=None,
+        stderr=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             set +e
@@ -36,9 +40,13 @@ class Metis:
             """
         )
 
-
     @bash_task
-    def make(self, stdout=None, stderr=None, clone=None):
+    def make(
+        self,
+        stdout=None,
+        stderr=None,
+        clone=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             set +e
@@ -56,7 +64,13 @@ class Metis:
         )
 
     @join_task
-    def install(self, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
+    def install(
+        self,
+        stdout=None,
+        stderr=None,
+        clone_executor="service",
+        make_executor="service",
+    ):
         clone = self.clone(
             stdout=(stdout, "w"),
             stderr=(stderr, "w"),
@@ -67,12 +81,18 @@ class Metis:
             stderr=(stderr, "a"),
             executor=make_executor,
             clone=clone,
-            )
+        )
         return make
 
-
     @bash_task
-    def gpmetis(self, mesh_file, nprocs, stdout=None, stderr=None, install=None):
+    def gpmetis(
+        self,
+        mesh_file,
+        nprocs,
+        stdout=None,
+        stderr=None,
+        install=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)

--- a/src/chiltepin/metis/wrapper.py
+++ b/src/chiltepin/metis/wrapper.py
@@ -1,7 +1,6 @@
 import textwrap
 
-from parsl.app.app import bash_app, join_app
-
+from chiltepin.tasks import bash_task, join_task
 
 class Metis:
 
@@ -15,17 +14,11 @@ class Metis:
         self.install_path = install_path
         self.tag = tag
 
-    def get_clone_task(
-        self,
-        executors=["service"],
-    ):
-        def clone(
-            stdout=None,
-            stderr=None,
-        ):
 
-            return self.environment + textwrap.dedent(
-                f"""
+    @bash_task
+    def clone(self, stdout=None, stderr=None):
+        return self.environment + textwrap.dedent(
+            f"""
             set +e
             echo Started at $(date)
             echo Executing on $(hostname)
@@ -41,22 +34,13 @@ class Metis:
             rm -f metis-{self.tag}.tar.gz
             echo Completed at $(date)
             """
-            )
+        )
 
-        return bash_app(clone, executors=executors)
 
-    def get_make_task(
-        self,
-        executors=["service"],
-    ):
-        def make(
-            stdout=None,
-            stderr=None,
-            jobs=8,
-            clone=None,
-        ):
-            return self.environment + textwrap.dedent(
-                f"""
+    @bash_task
+    def make(self, stdout=None, stderr=None, clone=None):
+        return self.environment + textwrap.dedent(
+            f"""
             set +e
             echo Started at $(date)
             echo Executing on $(hostname)
@@ -69,117 +53,31 @@ class Metis:
             rm -rf {self.install_path}/metis/build
             echo Completed at $(date)
             """
+        )
+
+    @join_task
+    def install(self, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
+        clone = self.clone(
+            stdout=(stdout, "w"),
+            stderr=(stderr, "w"),
+            executor=clone_executor,
+        )
+        make = self.make(
+            stdout=(stdout, "a"),
+            stderr=(stderr, "a"),
+            executor=make_executor,
+            clone=clone,
             )
+        return make
 
-        return bash_app(make, executors=executors)
 
-    def get_install_task(
-        self,
-        clone_executors=["service"],
-        make_executors=["service"],
-    ):
-        def install(
-            jobs=8,
-            stdout=None,
-            stderr=None,
-        ):
-            clone_task = self.get_clone_task(executors=clone_executors)
-            make_task = self.get_make_task(executors=make_executors)
-
-            clone = clone_task(
-                stdout=(stdout, "w"),
-                stderr=(stderr, "w"),
-            )
-            make = make_task(
-                jobs=jobs,
-                stdout=(stdout, "a"),
-                stderr=(stderr, "a"),
-                clone=clone,
-            )
-            return make
-
-        return join_app(install)
-
-    def get_gpmetis_task(
-        self,
-        executors=["compute"],
-    ):
-        def gpmetis(
-            mesh_file,
-            nprocs,
-            stdout=None,
-            stderr=None,
-            install=None,
-        ):
-
-            return self.environment + textwrap.dedent(
-                f"""
+    @bash_task
+    def gpmetis(self, mesh_file, nprocs, stdout=None, stderr=None, install=None):
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             {self.install_path}/metis/{self.tag}/bin/gpmetis -minconn -contig -niter=200 {mesh_file} {nprocs}
             echo Completed at $(date)
             """
-            )
-
-        return bash_app(gpmetis, executors=executors)
-
-    def clone(
-        self,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-    ):
-        return self.get_clone_task(executors=executors)(
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def make(
-        self,
-        clone=None,
-        jobs=8,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-        parsl_resource_specification={"num_nodes": 1},
-    ):
-        return self.get_make_task(executors=executors)(
-            clone=clone,
-            jobs=jobs,
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def install(
-        self,
-        jobs=8,
-        stdout=None,
-        stderr=None,
-        clone_executors=["service"],
-        make_executors=["service"],
-    ):
-        return self.get_install_task(
-            clone_executors=clone_executors,
-            make_executors=make_executors,
-        )(
-            jobs=jobs,
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def gpmetis(
-        self,
-        mesh_file,
-        nprocs,
-        stdout=None,
-        stderr=None,
-        install=None,
-        executors=["compute"],
-    ):
-        return self.get_gpmetis_task(executors=executors)(
-            mesh_file,
-            nprocs,
-            stdout=stdout,
-            stderr=stderr,
-            install=install,
         )

--- a/src/chiltepin/mpas/limited_area/wrapper.py
+++ b/src/chiltepin/mpas/limited_area/wrapper.py
@@ -16,7 +16,11 @@ class LimitedArea:
         self.tag = tag
 
     @bash_task
-    def install(self, stdout=None, stderr=None):
+    def install(
+        self,
+        stdout=None,
+        stderr=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)
@@ -33,7 +37,14 @@ class LimitedArea:
         )
 
     @bash_task
-    def create_region(self, resolution, region, stdout=None, stderr=None, install=None):
+    def create_region(
+        self,
+        resolution,
+        region,
+        stdout=None,
+        stderr=None,
+        install=None,
+    ):
         resolution_cells = {
             480: 2562,
             384: 4002,

--- a/src/chiltepin/mpas/limited_area/wrapper.py
+++ b/src/chiltepin/mpas/limited_area/wrapper.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from chiltepin.tasks import bash_task, join_task
+from chiltepin.tasks import bash_task
 
 
 class LimitedArea:
@@ -14,7 +14,6 @@ class LimitedArea:
         self.environment = environment
         self.install_path = install_path
         self.tag = tag
-
 
     @bash_task
     def install(self, stdout=None, stderr=None):
@@ -32,7 +31,6 @@ class LimitedArea:
             echo Completed at $(date)
             """
         )
-
 
     @bash_task
     def create_region(self, resolution, region, stdout=None, stderr=None, install=None):

--- a/src/chiltepin/mpas/limited_area/wrapper.py
+++ b/src/chiltepin/mpas/limited_area/wrapper.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from parsl.app.app import bash_app, join_app
+from chiltepin.tasks import bash_task, join_task
 
 
 class LimitedArea:
@@ -15,17 +15,11 @@ class LimitedArea:
         self.install_path = install_path
         self.tag = tag
 
-    def get_clone_task(
-        self,
-        executors=["service"],
-    ):
-        def clone(
-            stdout=None,
-            stderr=None,
-        ):
 
-            return self.environment + textwrap.dedent(
-                f"""
+    @bash_task
+    def install(self, stdout=None, stderr=None):
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             git lfs install --skip-repo
@@ -37,61 +31,34 @@ class LimitedArea:
             rm -f v{self.tag}.tar.gz
             echo Completed at $(date)
             """
-            )
+        )
 
-        return bash_app(clone, executors=executors)
 
-    def get_install_task(
-        self,
-        clone_executors=["service"],
-    ):
-        def install(
-            stdout=None,
-            stderr=None,
-        ):
-            clone_task = self.get_clone_task(executors=clone_executors)
+    @bash_task
+    def create_region(self, resolution, region, stdout=None, stderr=None, install=None):
+        resolution_cells = {
+            480: 2562,
+            384: 4002,
+            240: 10242,
+            120: 40962,
+            60: 163842,
+            48: 256002,
+            30: 655362,
+            24: 1024002,
+            15: 2621442,
+            12: 4096002,
+            10: 5898242,
+            7.5: 10485762,
+            5: 23592962,
+            4: 36864002,
+            3.75: 41943042,
+            3: 65536002,
+        }
 
-            clone = clone_task(
-                stdout=(stdout, "w"),
-                stderr=(stderr, "w"),
-            )
-            return clone
+        static_url = "https://www2.mmm.ucar.edu/projects/mpas/atmosphere_meshes"
 
-        return join_app(install)
-
-    def get_create_region_task(
-        self,
-        executors=["service"],
-    ):
-        def create_region(
-            resolution,
-            region,
-            stdout=None,
-            stderr=None,
-            install=None,
-        ):
-            resolution_cells = {
-                480: 2562,
-                384: 4002,
-                240: 10242,
-                120: 40962,
-                60: 163842,
-                48: 256002,
-                30: 655362,
-                24: 1024002,
-                15: 2621442,
-                12: 4096002,
-                10: 5898242,
-                7.5: 10485762,
-                5: 23592962,
-                4: 36864002,
-                3.75: 41943042,
-                3: 65536002,
-            }
-            static_url = "https://www2.mmm.ucar.edu/projects/mpas/atmosphere_meshes"
-
-            return self.environment + textwrap.dedent(
-                f"""
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             echo downloading static files
@@ -106,47 +73,4 @@ class LimitedArea:
                 x1.{resolution_cells[resolution]}.static.nc
             echo Completed at $(date)
             """
-            )
-
-        return bash_app(create_region, executors=executors)
-
-    def clone(
-        self,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-    ):
-        return self.get_clone_task(executors=executors)(
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def install(
-        self,
-        stdout=None,
-        stderr=None,
-        clone_executors=["service"],
-    ):
-        return self.get_install_task(
-            clone_executors=clone_executors,
-        )(
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def create_region(
-        self,
-        resolution,
-        region,
-        stdout=None,
-        stderr=None,
-        install=None,
-        executors=["service"],
-    ):
-        return self.get_create_region_task(executors=executors)(
-            resolution,
-            region,
-            stdout=stdout,
-            stderr=stderr,
-            install=install,
         )

--- a/src/chiltepin/mpas/wrapper.py
+++ b/src/chiltepin/mpas/wrapper.py
@@ -1,7 +1,7 @@
 import textwrap
 from datetime import datetime
 
-from parsl.app.app import bash_app, join_app
+from chiltepin.tasks import bash_task, join_task
 from uwtools.api import config as uwconfig
 
 
@@ -17,17 +17,10 @@ class MPAS:
         self.install_path = install_path
         self.tag = tag
 
-    def get_clone_task(
-        self,
-        executors=["service"],
-    ):
-        def clone(
-            stdout=None,
-            stderr=None,
-        ):
-
-            return self.environment + textwrap.dedent(
-                f"""
+    @bash_task
+    def clone(self, stdout=None, stderr=None):
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             git lfs install --skip-repo
@@ -38,26 +31,16 @@ class MPAS:
             git checkout {self.tag}
             echo Completed at $(date)
             """
-            )
+        )
 
-        return bash_app(clone, executors=executors)
-
-    def get_make_task(
-        self,
-        executors=["service"],
-    ):
-        def make(
-            stdout=None,
-            stderr=None,
-            jobs=8,
-            clone=None,
-        ):
-            repo_url = (
-                "https://raw.githubusercontent.com/NOAA-GSL/ExascaleWorkflowSandbox/"
-            )
-            patch_url = repo_url + "main/apps/mpas/patches"
-            return self.environment + textwrap.dedent(
-                f"""
+    @bash_task
+    def make(self, jobs=8, stdout=None, stderr=None, clone=None):
+        repo_url = (
+            "https://raw.githubusercontent.com/NOAA-GSL/ExascaleWorkflowSandbox/"
+        )
+        patch_url = repo_url + "main/apps/mpas/patches"
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             cd {self.install_path}/mpas/{self.tag}
@@ -84,59 +67,37 @@ class MPAS:
 
             echo Completed at $(date)
             """
-            )
+        )
 
-        return bash_app(make, executors=executors)
 
-    def get_install_task(
-        self,
-        clone_executors=["service"],
-        make_executors=["service"],
-    ):
-        def install(
-            jobs=8,
-            stdout=None,
-            stderr=None,
-        ):
-            clone_task = self.get_clone_task(executors=clone_executors)
-            make_task = self.get_make_task(executors=make_executors)
+    @join_task
+    def install(self, jobs=8, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
+        clone = self.clone(
+            stdout=(stdout, "w"),
+            stderr=(stderr, "w"),
+            executor=clone_executor,
+        )
+        make = self.make(
+            jobs=jobs,
+            stdout=(stdout, "a"),
+            stderr=(stderr, "a"),
+            executor=make_executor,
+            clone=clone,
+        )
+        return make
 
-            clone = clone_task(
-                stdout=(stdout, "w"),
-                stderr=(stderr, "w"),
-            )
-            make = make_task(
-                jobs=jobs,
-                stdout=(stdout, "a"),
-                stderr=(stderr, "a"),
-                clone=clone,
-            )
-            return make
 
-        return join_app(install)
+    @bash_task
+    def mpas_init(self, config_path, cycle_str, key_path, stdout=None, stderr=None, install=None, parsl_resource_specification={}):
 
-    def get_mpas_init_task(
-        self,
-        executors=["mpi"],
-    ):
-        def mpas_init(
-            config_path,
-            cycle_str,
-            key_path,
-            stdout=None,
-            stderr=None,
-            install=None,
-            parsl_resource_specification={},
-        ):
+        cycle = datetime.fromisoformat(cycle_str)
 
-            cycle = datetime.fromisoformat(cycle_str)
+        # Extract driver config from experiment config
+        expt_config = uwconfig.get_yaml_config(config_path)
+        expt_config.dereference(context={"cycle": cycle, **expt_config})
 
-            # Extract driver config from experiment config
-            expt_config = uwconfig.get_yaml_config(config_path)
-            expt_config.dereference(context={"cycle": cycle, **expt_config})
-
-            return self.environment + textwrap.dedent(
-                f"""
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             export PATH=$PATH:.
@@ -147,32 +108,19 @@ class MPAS:
             $PARSL_MPI_PREFIX --overcommit {self.install_path}/mpas/{self.tag}/exe/init_atmosphere_model
             echo Completed at $(date)
             """
-            )
+        )
 
-        return bash_app(mpas_init, executors=executors)
 
-    def get_mpas_forecast_task(
-        self,
-        executors=["mpi"],
-    ):
-        def mpas_forecast(
-            config_path,
-            cycle_str,
-            key_path,
-            stdout=None,
-            stderr=None,
-            install=None,
-            parsl_resource_specification={},
-        ):
+    @bash_task
+    def mpas_forecast(self, config_path, cycle_str, key_path, stdout=None, stderr=None, install=None, parsl_resource_specification={}):
+        cycle = datetime.fromisoformat(cycle_str)
 
-            cycle = datetime.fromisoformat(cycle_str)
+        # Extract driver config from experiment config
+        expt_config = uwconfig.get_yaml_config(config_path)
+        expt_config.dereference(context={"cycle": cycle, **expt_config})
 
-            # Extract driver config from experiment config
-            expt_config = uwconfig.get_yaml_config(config_path)
-            expt_config.dereference(context={"cycle": cycle, **expt_config})
-
-            return self.environment + textwrap.dedent(
-                f"""
+        return self.environment + textwrap.dedent(
+            f"""
             echo Started at $(date)
             echo Executing on $(hostname)
             export PATH=$PATH:.
@@ -183,99 +131,4 @@ class MPAS:
             $PARSL_MPI_PREFIX --overcommit {self.install_path}/mpas/{self.tag}/exe/atmosphere_model
             echo Completed at $(date)
             """
-            )
-
-        return bash_app(mpas_forecast, executors=executors)
-
-    def clone(
-        self,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-    ):
-        return self.get_clone_task(executors=executors)(
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def make(
-        self,
-        clone=None,
-        jobs=8,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-    ):
-        return self.get_make_task(executors=executors)(
-            clone=clone,
-            jobs=jobs,
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def install(
-        self,
-        jobs=8,
-        stdout=None,
-        stderr=None,
-        clone_executors=["service"],
-        make_executors=["service"],
-    ):
-        return self.get_install_task(
-            clone_executors=clone_executors,
-            make_executors=make_executors,
-        )(
-            jobs=jobs,
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def mpas_init(
-        self,
-        config_path,
-        cycle_str,
-        key_path,
-        stdout=None,
-        stderr=None,
-        install=None,
-        executors=["mpi"],
-        parsl_resource_specification={
-            "num_nodes": 1,  # Number of nodes required for the application instance
-            "num_ranks": 4,  # Number of ranks in total
-            "ranks_per_node": 4,  # Number of MPI ranks per node
-        },
-    ):
-        return self.get_mpas_init_task(executors=executors)(
-            config_path,
-            cycle_str,
-            key_path,
-            stdout=stdout,
-            stderr=stderr,
-            install=install,
-            parsl_resource_specification=parsl_resource_specification,
-        )
-
-    def mpas_forecast(
-        self,
-        config_path,
-        cycle_str,
-        key_path,
-        stdout=None,
-        stderr=None,
-        install=None,
-        executors=["mpi"],
-        parsl_resource_specification={
-            "num_nodes": 1,  # Number of nodes required for the application instance
-            "num_ranks": 32,  # Number of ranks in total
-            "ranks_per_node": 32,  # Number of MPI ranks per node
-        },
-    ):
-        return self.get_mpas_forecast_task(executors=executors)(
-            config_path,
-            cycle_str,
-            key_path,
-            stdout=stdout,
-            stderr=stderr,
-            install=install,
-            parsl_resource_specification=parsl_resource_specification,
         )

--- a/src/chiltepin/mpas/wrapper.py
+++ b/src/chiltepin/mpas/wrapper.py
@@ -1,8 +1,9 @@
 import textwrap
 from datetime import datetime
 
-from chiltepin.tasks import bash_task, join_task
 from uwtools.api import config as uwconfig
+
+from chiltepin.tasks import bash_task, join_task
 
 
 class MPAS:
@@ -18,7 +19,11 @@ class MPAS:
         self.tag = tag
 
     @bash_task
-    def clone(self, stdout=None, stderr=None):
+    def clone(
+        self,
+        stdout=None,
+        stderr=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)
@@ -34,10 +39,14 @@ class MPAS:
         )
 
     @bash_task
-    def make(self, jobs=8, stdout=None, stderr=None, clone=None):
-        repo_url = (
-            "https://raw.githubusercontent.com/NOAA-GSL/ExascaleWorkflowSandbox/"
-        )
+    def make(
+        self,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        clone=None,
+    ):
+        repo_url = "https://raw.githubusercontent.com/NOAA-GSL/ExascaleWorkflowSandbox/"
         patch_url = repo_url + "main/apps/mpas/patches"
         return self.environment + textwrap.dedent(
             f"""
@@ -69,9 +78,15 @@ class MPAS:
             """
         )
 
-
     @join_task
-    def install(self, jobs=8, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
+    def install(
+        self,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        clone_executor="service",
+        make_executor="service",
+    ):
         clone = self.clone(
             stdout=(stdout, "w"),
             stderr=(stderr, "w"),
@@ -86,9 +101,17 @@ class MPAS:
         )
         return make
 
-
     @bash_task
-    def mpas_init(self, config_path, cycle_str, key_path, stdout=None, stderr=None, install=None, parsl_resource_specification={}):
+    def mpas_init(
+        self,
+        config_path,
+        cycle_str,
+        key_path,
+        stdout=None,
+        stderr=None,
+        install=None,
+        parsl_resource_specification={},
+    ):
 
         cycle = datetime.fromisoformat(cycle_str)
 
@@ -110,9 +133,17 @@ class MPAS:
             """
         )
 
-
     @bash_task
-    def mpas_forecast(self, config_path, cycle_str, key_path, stdout=None, stderr=None, install=None, parsl_resource_specification={}):
+    def mpas_forecast(
+        self,
+        config_path,
+        cycle_str,
+        key_path,
+        stdout=None,
+        stderr=None,
+        install=None,
+        parsl_resource_specification={},
+    ):
         cycle = datetime.fromisoformat(cycle_str)
 
         # Extract driver config from experiment config

--- a/src/chiltepin/tasks.py
+++ b/src/chiltepin/tasks.py
@@ -1,0 +1,101 @@
+from parsl.app.app import bash_app, join_app, python_app
+from functools import wraps
+from typing import Callable
+
+def python_task(function: Callable) -> Callable:
+    """Decorator function for making Chiltepin python tasks.
+
+    The decorator transforms the function into a Parsl python_app but adds an executor
+    argument such that the executor for the function can be chosen dynamically at runtime.
+
+    Parameters
+    ----------
+
+    function: Callable
+        The function to be decorated to yield a Python workflow task. This function can be a
+        stand-alone function or a class method. If it is a class method, it can make use of
+        `self` to access object state.
+
+
+    Returns
+    -------
+
+    Callable
+
+    """
+    @wraps(function)
+    def function_wrapper(
+            *args,
+            executor='all',
+            **kwargs,
+    ):
+        return python_app(function, executors=[executor])(*args, **kwargs)
+    
+    return function_wrapper
+
+
+def bash_task(function: Callable) -> Callable:
+    """Decorator function for making Chiltepin bash tasks.
+
+    The decorator transforms the function into a Parsl bash_app but adds an executor
+    argument such that the executor for the function can be chosen dynamically at runtime.
+
+    Parameters
+    ----------
+
+    function: Callable
+        The function to be decorated to yield a Bash workflow task. This function can be a
+        stand-alone function or a class method. If it is a class method, it can make use of
+        `self` to access object state. The function must return a string that contains a
+        series of bash commands to be executed.  
+
+
+    Returns
+    -------
+
+    Callable
+
+    """
+    @wraps(function)
+    def function_wrapper(
+            *args,
+            executor='all',
+            **kwargs,
+    ):
+        return bash_app(function, executors=[executor])(*args, **kwargs)
+    
+    return function_wrapper
+
+
+def join_task(function: Callable) -> Callable:
+    """Decorator function for making Chiltepin join tasks.
+
+    The decorator transforms the function into a Parsl join_app. A parsl @join_app decorator
+    accomplishes the same thing.  This decorator is added to provide API consistency so that
+    users can use @join_task rather than @join_app along with @python_task and @bash_task.
+
+    Parameters
+    ----------
+
+    function: Callable
+        The function to be decorated to yield a join workflow task. This function can be a
+        stand-alone function or a class method. If it is a class method, it can make use of
+        `self` to access object state. The function is expected to call multiple python or
+        bash tasks and return a Future that encapsulates the result of those tasks.
+
+
+    Returns
+    -------
+
+    Callable
+
+    """
+    @wraps(function)
+    def function_wrapper(
+            *args,
+            **kwargs,
+    ):
+        return join_app(function)(*args, **kwargs)
+    
+    return function_wrapper
+            

--- a/src/chiltepin/tasks.py
+++ b/src/chiltepin/tasks.py
@@ -1,6 +1,8 @@
-from parsl.app.app import bash_app, join_app, python_app
 from functools import wraps
 from typing import Callable
+
+from parsl.app.app import bash_app, join_app, python_app
+
 
 def python_task(function: Callable) -> Callable:
     """Decorator function for making Chiltepin python tasks.
@@ -23,14 +25,15 @@ def python_task(function: Callable) -> Callable:
     Callable
 
     """
+
     @wraps(function)
     def function_wrapper(
-            *args,
-            executor='all',
-            **kwargs,
+        *args,
+        executor="all",
+        **kwargs,
     ):
         return python_app(function, executors=[executor])(*args, **kwargs)
-    
+
     return function_wrapper
 
 
@@ -47,7 +50,7 @@ def bash_task(function: Callable) -> Callable:
         The function to be decorated to yield a Bash workflow task. This function can be a
         stand-alone function or a class method. If it is a class method, it can make use of
         `self` to access object state. The function must return a string that contains a
-        series of bash commands to be executed.  
+        series of bash commands to be executed.
 
 
     Returns
@@ -56,14 +59,15 @@ def bash_task(function: Callable) -> Callable:
     Callable
 
     """
+
     @wraps(function)
     def function_wrapper(
-            *args,
-            executor='all',
-            **kwargs,
+        *args,
+        executor="all",
+        **kwargs,
     ):
         return bash_app(function, executors=[executor])(*args, **kwargs)
-    
+
     return function_wrapper
 
 
@@ -90,12 +94,12 @@ def join_task(function: Callable) -> Callable:
     Callable
 
     """
+
     @wraps(function)
     def function_wrapper(
-            *args,
-            **kwargs,
+        *args,
+        **kwargs,
     ):
         return join_app(function)(*args, **kwargs)
-    
+
     return function_wrapper
-            

--- a/src/chiltepin/wps/wrapper.py
+++ b/src/chiltepin/wps/wrapper.py
@@ -15,7 +15,6 @@ class WPS:
         self.install_path = install_path
         self.tag = tag
 
-
     @bash_task
     def clone(self, stdout=None, stderr=None):
         return self.environment + textwrap.dedent(
@@ -32,7 +31,6 @@ class WPS:
             echo Completed at $(date)
             """
         )
-
 
     @bash_task
     def make(self, WRF_dir=None, jobs=8, stdout=None, stderr=None, clone=None):
@@ -83,9 +81,16 @@ class WPS:
             """
         )
 
-
     @join_task
-    def install(self, WRF_dir=None, jobs=None, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
+    def install(
+        self,
+        WRF_dir=None,
+        jobs=None,
+        stdout=None,
+        stderr=None,
+        clone_executor="service",
+        make_executor="service",
+    ):
         clone = self.clone(
             stdout=(stdout, "w"),
             stderr=(stderr, "w"),
@@ -100,7 +105,6 @@ class WPS:
             clone=clone,
         )
         return make
-
 
     @bash_task
     def ungrib(self, config_path, cycle_str, stdout=None, stderr=None, install=None):

--- a/src/chiltepin/wps/wrapper.py
+++ b/src/chiltepin/wps/wrapper.py
@@ -16,7 +16,11 @@ class WPS:
         self.tag = tag
 
     @bash_task
-    def clone(self, stdout=None, stderr=None):
+    def clone(
+        self,
+        stdout=None,
+        stderr=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)
@@ -33,7 +37,14 @@ class WPS:
         )
 
     @bash_task
-    def make(self, WRF_dir=None, jobs=8, stdout=None, stderr=None, clone=None):
+    def make(
+        self,
+        WRF_dir=None,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        clone=None,
+    ):
         if WRF_dir is None:
             no_wrf = "--nowrf"
         else:
@@ -107,7 +118,14 @@ class WPS:
         return make
 
     @bash_task
-    def ungrib(self, config_path, cycle_str, stdout=None, stderr=None, install=None):
+    def ungrib(
+        self,
+        config_path,
+        cycle_str,
+        stdout=None,
+        stderr=None,
+        install=None,
+    ):
         return self.environment + textwrap.dedent(
             f"""
             echo Started at $(date)

--- a/src/chiltepin/wrf/wrapper.py
+++ b/src/chiltepin/wrf/wrapper.py
@@ -15,51 +15,66 @@ class WRF:
         self.install_path = install_path
         self.tag = tag
 
-   @bash_task
-   def clone(self, stdout=None, stderr=None):
-       return self.environment + textwrap.dedent(
-           f"""
-           echo Started at $(date)
-           echo Executing on $(hostname)
-           git lfs install --skip-repo
-           rm -rf {self.install_path}/WRF/{self.tag}
-           mkdir -p {self.install_path}/WRF/{self.tag}
-           cd {self.install_path}/WRF/{self.tag}
-           wget https://github.com/wrf-model/WRF/releases/download/v{self.tag}/v{self.tag}.tar.gz
-           tar --strip-components=1 -xzf v{self.tag}.tar.gz
-           rm -f v{self.tag}.tar.gz
+    @bash_task
+    def clone(
+        self,
+        stdout=None,
+        stderr=None,
+    ):
+        return self.environment + textwrap.dedent(
+            f"""
+            echo Started at $(date)
+            echo Executing on $(hostname)
+            git lfs install --skip-repo
+            rm -rf {self.install_path}/WRF/{self.tag}
+            mkdir -p {self.install_path}/WRF/{self.tag}
+            cd {self.install_path}/WRF/{self.tag}
+            wget https://github.com/wrf-model/WRF/releases/download/v{self.tag}/v{self.tag}.tar.gz
+            tar --strip-components=1 -xzf v{self.tag}.tar.gz
+            rm -f v{self.tag}.tar.gz
+            echo Completed at $(date)
+            """
+        )
+
+    @bash_task
+    def make(
+        self,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        clone=None,
+    ):
+        return self.environment + textwrap.dedent(
+            f"""
+            echo Started at $(date)
+            echo Executing on $(hostname)
+            cd {self.install_path}/WRF/{self.tag}
+            export J="-j {jobs}"
+            echo "15" | ./configure
+            ./compile em_real
            echo Completed at $(date)
-           """
-       )
+            """
+        )
 
-
-   @bash_task
-   def make(self, jobs=8, stdout=None, stderr=None, clone=None):
-       return self.environment + textwrap.dedent(
-           f"""
-           echo Started at $(date)
-           echo Executing on $(hostname)
-           cd {self.install_path}/WRF/{self.tag}
-           export J="-j {jobs}"
-           echo "15" | ./configure
-           ./compile em_real
-           echo Completed at $(date)
-           """
-       )
-
-
-   @join_task
-   def install(self, jobs=8, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
-       clone = clone_task(
-           stdout=(stdout, "w"),
-           stderr=(stderr, "w"),
-           executor=clone_executor,
-       )
-       make = make_task(
-           jobs=jobs,
-           stdout=(stdout, "a"),
-           stderr=(stderr, "a"),
-           executor=make_executor,
-           clone=clone,
-       )
-       return make
+    @join_task
+    def install(
+        self,
+        jobs=8,
+        stdout=None,
+        stderr=None,
+        clone_executor="service",
+        make_executor="service",
+    ):
+        clone = self.clone(
+            stdout=(stdout, "w"),
+            stderr=(stderr, "w"),
+            executor=clone_executor,
+        )
+        make = self.make(
+            jobs=jobs,
+            stdout=(stdout, "a"),
+            stderr=(stderr, "a"),
+            executor=make_executor,
+            clone=clone,
+        )
+        return make

--- a/src/chiltepin/wrf/wrapper.py
+++ b/src/chiltepin/wrf/wrapper.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from parsl.app.app import bash_app, join_app
+from chiltepin.tasks import bash_task, join_task
 
 
 class WRF:
@@ -15,125 +15,51 @@ class WRF:
         self.install_path = install_path
         self.tag = tag
 
-    def get_clone_task(
-        self,
-        executors=["service"],
-    ):
-        def clone(
-            stdout=None,
-            stderr=None,
-        ):
+   @bash_task
+   def clone(self, stdout=None, stderr=None):
+       return self.environment + textwrap.dedent(
+           f"""
+           echo Started at $(date)
+           echo Executing on $(hostname)
+           git lfs install --skip-repo
+           rm -rf {self.install_path}/WRF/{self.tag}
+           mkdir -p {self.install_path}/WRF/{self.tag}
+           cd {self.install_path}/WRF/{self.tag}
+           wget https://github.com/wrf-model/WRF/releases/download/v{self.tag}/v{self.tag}.tar.gz
+           tar --strip-components=1 -xzf v{self.tag}.tar.gz
+           rm -f v{self.tag}.tar.gz
+           echo Completed at $(date)
+           """
+       )
 
-            return self.environment + textwrap.dedent(
-                f"""
-            echo Started at $(date)
-            echo Executing on $(hostname)
-            git lfs install --skip-repo
-            rm -rf {self.install_path}/WRF/{self.tag}
-            mkdir -p {self.install_path}/WRF/{self.tag}
-            cd {self.install_path}/WRF/{self.tag}
-            wget https://github.com/wrf-model/WRF/releases/download/v{self.tag}/v{self.tag}.tar.gz
-            tar --strip-components=1 -xzf v{self.tag}.tar.gz
-            rm -f v{self.tag}.tar.gz
-            echo Completed at $(date)
-            """
-            )
 
-        return bash_app(clone, executors=executors)
+   @bash_task
+   def make(self, jobs=8, stdout=None, stderr=None, clone=None):
+       return self.environment + textwrap.dedent(
+           f"""
+           echo Started at $(date)
+           echo Executing on $(hostname)
+           cd {self.install_path}/WRF/{self.tag}
+           export J="-j {jobs}"
+           echo "15" | ./configure
+           ./compile em_real
+           echo Completed at $(date)
+           """
+       )
 
-    def get_make_task(
-        self,
-        executors=["compute"],
-    ):
-        def make(
-            stdout=None,
-            stderr=None,
-            jobs=8,
-            clone=None,
-            parsl_resource_specification={"num_nodes": 1},
-        ):
-            return self.environment + textwrap.dedent(
-                f"""
-            echo Started at $(date)
-            echo Executing on $(hostname)
-            cd {self.install_path}/WRF/{self.tag}
-            export J="-j {jobs}"
-            echo "15" | ./configure
-            ./compile em_real
-            echo Completed at $(date)
-            """
-            )
 
-        return bash_app(make, executors=executors)
-
-    def get_install_task(
-        self,
-        clone_executors=["service"],
-        make_executors=["service"],
-    ):
-        def install(
-            jobs=8,
-            stdout=None,
-            stderr=None,
-        ):
-            clone_task = self.get_clone_task(executors=clone_executors)
-            make_task = self.get_make_task(executors=make_executors)
-
-            clone = clone_task(
-                stdout=(stdout, "w"),
-                stderr=(stderr, "w"),
-            )
-            make = make_task(
-                jobs=jobs,
-                stdout=(stdout, "a"),
-                stderr=(stderr, "a"),
-                clone=clone,
-            )
-            return make
-
-        return join_app(install)
-
-    def clone(
-        self,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-    ):
-        return self.get_clone_task(executors=executors)(
-            stdout=stdout,
-            stderr=stderr,
-        )
-
-    def make(
-        self,
-        clone=None,
-        jobs=8,
-        stdout=None,
-        stderr=None,
-        executors=["service"],
-        parsl_resource_specification={"num_nodes": 1},
-    ):
-        return self.get_make_task(executors=executors)(
-            clone=clone,
-            jobs=jobs,
-            stdout=stdout,
-            stderr=stderr,
-            parsl_resource_specification=parsl_resource_specification,
-        )
-
-    def install(
-        self,
-        jobs=8,
-        stdout=None,
-        stderr=None,
-        clone_executors=["service"],
-        make_executors=["service"],
-    ):
-        return self.get_install_task(
-            clone_executors=clone_executors,
-            make_executors=make_executors,
-        )(
-            jobs=jobs,
-            stdout=stdout,
-            stderr=stderr,
-        )
+   @join_task
+   def install(self, jobs=8, stdout=None, stderr=None, clone_executor="service", make_executor="service"):
+       clone = clone_task(
+           stdout=(stdout, "w"),
+           stderr=(stderr, "w"),
+           executor=clone_executor,
+       )
+       make = make_task(
+           jobs=jobs,
+           stdout=(stdout, "a"),
+           stderr=(stderr, "a"),
+           executor=make_executor,
+           clone=clone,
+       )
+       return make

--- a/tests/test_qg_install.py
+++ b/tests/test_qg_install.py
@@ -31,9 +31,9 @@ def test_qg_install(config):
         jobs=8,
         stdout="qg_install.out",
         stderr="qg_install.err",
-        clone_executors=["service"],
-        configure_executors=["service"],
-        make_executors=["compute"],
+        clone_executor="service",
+        configure_executor="service",
+        make_executor="compute",
     ).result()
 
     assert install_result == 0


### PR DESCRIPTION
This PR adds task decorators: `@python_task`, `@bash_task`, and `@join_task`.  These decorators return corresponding Parsl Apps but offer two important enhancements.  First, the new task decorators can be used for class methods that use `self` to access object state. Second, they allow the tasks to be run on executors that are chosen at runtime.

Closes #124 