### PR TITLE
Add an endpoint API and CLI for manipulating globus compute endpoints

### DIFF
--- a/src/chiltepin/cli.py
+++ b/src/chiltepin/cli.py
@@ -1,0 +1,76 @@
+import argparse
+
+import chiltepin.endpoint as endpoint
+
+
+def cli_list(config_dir=None):
+    ep_list = endpoint.list(config_dir=config_dir)
+    if ep_list:
+        name_len = max(len(key) for key in ep_list)
+        for name, props in ep_list.items():
+            print(f"{name:<{name_len}} {props['id']} {props['state']}")
+    else:
+        print("No endpoints are configured")
+
+
+# Create root level parser
+root_parser = argparse.ArgumentParser(prog="chiltepin")
+
+# Add subparsers for the chiltepin subcommands
+cmd_parsers = root_parser.add_subparsers(
+    title="chiltepin commands",
+    help="Chiltepin commands",
+)
+
+# Add parser for the endpoint command
+endpoint_parser = cmd_parsers.add_parser(
+    "endpoint",
+    help="endpoint commands",
+)
+endpoint_parser.add_argument(
+    "-c",
+    "--config",
+    dest="config_dir",
+    help="configuration directory",
+)
+
+# Add subparsers for the endpoint subcommands
+endpoint_parsers = endpoint_parser.add_subparsers(
+    title="endpoint commands",
+    help="endpoint commands",
+)
+
+# Add parser for endpoint configure command
+configure_parser = endpoint_parsers.add_parser(
+    "configure",
+    help="configure an endpoint",
+)
+configure_parser.add_argument("name", help="name of endpoint to configure")
+configure_parser.set_defaults(func=endpoint.configure)
+
+# Add parser for endpoint list command
+list_parser = endpoint_parsers.add_parser("list", help="List endpoints")
+list_parser.set_defaults(func=cli_list)
+
+# Add parser for endpoint start command
+start_parser = endpoint_parsers.add_parser("start", help="start an endpoint")
+start_parser.add_argument("name", help="name of endpoint to start")
+start_parser.set_defaults(func=endpoint.start)
+
+# Add parser for endpoint stop command
+stop_parser = endpoint_parsers.add_parser("stop", help="stop an endpoint")
+stop_parser.add_argument("name", help="name of endpoint to stop")
+stop_parser.set_defaults(func=endpoint.stop)
+
+# Add parser for endpoint delete command
+delete_parser = endpoint_parsers.add_parser("delete", help="delete an endpoint")
+delete_parser.add_argument("name", help="name of endpoint to delete")
+delete_parser.set_defaults(func=endpoint.delete)
+
+
+def main():
+    args = root_parser.parse_args()
+    if hasattr(args, "name"):
+        args.func(args.name, config_dir=args.config_dir)
+    else:
+        args.func(config_dir=args.config_dir)

--- a/src/chiltepin/configure.py
+++ b/src/chiltepin/configure.py
@@ -8,7 +8,6 @@ from parsl.launchers import SimpleLauncher
 from parsl.providers import SlurmProvider
 
 
-# Define function to parse yaml config
 def parse_file(filename: str) -> Dict[str, Any]:
     """Parse a YAML resource comfiguration file and return its contents as a dict
 

--- a/src/chiltepin/endpoint.py
+++ b/src/chiltepin/endpoint.py
@@ -1,0 +1,200 @@
+import os
+import re
+import subprocess
+from typing import Dict
+
+
+def configure(name: str, config_dir: str | None = None, timeout: int = 5):
+    """Configure a Globus Compute Endpoint
+
+    This is a thin wrapper around the globus-compute-endpoint configure command
+
+    Parameters
+    ----------
+
+    name: str
+        Name of the endpoint to configure
+
+    config_dir: str | None
+        Path to endpoint configuration directory where endpoint information
+        is to be stored. If None (the default), then $HOME/.globus_compute
+        is used
+
+    timeout: int
+        Number of seconds to wait for the command to complete before timing out
+    """
+    # Build the globus-compute-endpoint command to run
+    command = ["globus-compute-endpoint"]
+    if config_dir:
+        command.append("-c")
+        command.append(f"{os.path.abspath(config_dir)}")
+    command.append("configure")
+    command.append(name)
+    # Run the command as a sub process
+    p = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    assert p.returncode == 0, p.stdout
+
+
+def list(config_dir: str | None = None, timeout: int = 60) -> Dict[str, str]:
+    """Return a list of configured Globus Compute Endpoints
+
+    This is a thin wrapper around the globus-compute-endpoint list command.
+    The endpoint listing is returned as a dict with keys corresponding to
+    the endpoint names.
+
+    Parameters
+    ----------
+
+    config_dir: str | None
+        Path to endpoint configuration directory where endpoint information
+        is stored. If None (the default), then $HOME/.globus_compute is used
+
+    timeout: int
+        Number of seconds to wait for the command to complete before timing out
+
+    Returns
+    -------
+
+    Dict[str, str]
+    """
+    # Build the globus-compute-endpoint command to run
+    command = ["globus-compute-endpoint"]
+    if config_dir:
+        command.append("-c")
+        command.append(f"{os.path.abspath(config_dir)}")
+    command.append("list")
+    # Run the command as a subprocess
+    p = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    assert p.returncode == 0, p.stdout
+    # Build a dict from the output and return it
+    ep_list = {}
+    for line in p.stdout.split("\n"):
+        endpoint_regex = re.compile(
+            r"\|\s+([0-9a-f\-]{36}|None)\s+\|\s+([^\|\s]+)\s+\|\s+([^\|\s]+)\s+\|"
+        )
+        match = endpoint_regex.search(line)
+        if match is not None:
+            assert match.group(1) == "None" or len(match.group(1)) == 36
+            ep_list[match.group(3)] = {"id": match.group(1), "state": match.group(2)}
+    return ep_list
+
+
+def start(name: str, config_dir: str | None = None, timeout: int = 60):
+    """Start the specified Globus Compute Endpoint
+
+    This is a thin wrapper around the globus-compute-endpoint start command
+
+    Parameters
+    ----------
+
+    name: str
+        Name of the endpoint to start
+
+    config_dir: str | None
+        Path to endpoint configuration directory where endpoint information
+        is stored. If None (the default), then $HOME/.globus_compute is used
+
+    timeout: int
+        Number of seconds to wait for the command to complete before timing out
+    """
+    # Build the globus-compute-endpoint command to run
+    command = ["globus-compute-endpoint"]
+    if config_dir:
+        command.append("-c")
+        command.append(f"{os.path.abspath(config_dir)}")
+    command.append("start")
+    command.append(name)
+    # Run the command as a subprocess
+    p = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    assert p.returncode == 0, p.stdout
+
+
+def stop(name: str, config_dir: str | None = None, timeout: int = 60):
+    """Stop the specified Globus Compute Endpoint
+
+    This is a thin wrapper around the globus-compute-endpoint stop command
+
+    Parameters
+    ----------
+
+    name: str
+        Name of the endpoint to stop
+
+    config_dir: str | None
+        Path to endpoint configuration directory where endpoint information
+        is stored. If None (the default), then $HOME/.globus_compute is used
+
+    timeout: int
+        Number of seconds to wait for the command to complete before timing out
+    """
+    # Build the globus-compute-endpoint command to run
+    command = ["globus-compute-endpoint"]
+    if config_dir:
+        command.append("-c")
+        command.append(f"{os.path.abspath(config_dir)}")
+    command.append("stop")
+    command.append(name)
+    # Run the command as a subprocess
+    p = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    assert p.returncode == 0, p.stdout
+
+
+def delete(name: str, config_dir: str | None = None, timeout: int = 60):
+    """Delete the specified Globus Compute Endpoint
+
+    This is a thin wrapper around the globus-compute-endpoint delete command
+
+    Parameters
+    ----------
+
+    name: str
+        Name of the endpoint to delete
+
+    config_dir: str | None
+        Path to endpoint configuration directory where endpoint information
+        is stored. If None (the default), then $HOME/.globus_compute is used
+
+    timeout: int
+        Number of seconds to wait for the command to complete before timing out
+    """
+    # Build the globus-compute-endpoint command to run
+    command = ["globus-compute-endpoint"]
+    if config_dir:
+        command.append("-c")
+        command.append(f"{os.path.abspath(config_dir)}")
+    command.append("delete")
+    command.append("--yes")
+    command.append(name)
+    # Run the command as a subprocess
+    p = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    assert p.returncode == 0, p.stdout

--- a/tests/delete-endpoint.py
+++ b/tests/delete-endpoint.py
@@ -1,9 +1,25 @@
-import sys
-
 from globus_compute_sdk import Client
 
-ep = sys.argv[1]
-
-print(f"Deleting endpoint: {ep}")
 c = Client()
-c.delete_endpoint(ep)
+eps = []
+for ep in c.get_endpoints():
+    uuid = ep["uuid"]
+    name = ep["name"]
+    status = c.get_endpoint_status(uuid)["status"]
+    metadata = c.get_endpoint_metadata(uuid)
+    host = metadata["hostname"]
+    eps.append({"uuid": uuid, "name": name, "host": host, "status": status})
+    name_len = max(len(ep["name"]) for ep in eps)
+    host_len = max(len(ep["host"]) for ep in eps)
+    status_len = max(len(ep["status"]) for ep in eps)
+
+for ep in eps:
+    uuid = ep["uuid"]
+    name = ep["name"]
+    status = ep["status"]
+    host = ep["host"]
+    yes_no = input(
+        f"""Delete {uuid} :: {status:<{status_len}} :: {host:<{host_len}} :: {name:<{name_len}}? (y/N): """
+    )
+    if yes_no.lower() in ["yes", "y"]:
+        c.delete_endpoint(uuid)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,0 +1,95 @@
+import os
+import pathlib
+import shutil
+
+import chiltepin.endpoint as endpoint
+
+
+def test_endpoint_list_empty():
+    pwd = pathlib.Path(__file__).parent.resolve()
+    # Start from a clean state
+    if os.path.exists(f"{pwd}/.globus_compute"):
+        shutil.rmtree(f"{pwd}/.globus_compute")
+    # List endpoints with a config_dir
+    ep_list = endpoint.list(config_dir=f"{pwd}/.globus_compute")
+    assert ep_list == {}
+
+
+def test_endpoint_configure():
+    pwd = pathlib.Path(__file__).parent.resolve()
+    # Start from a clean state
+    if os.path.exists(f"{os.environ['HOME']}/.globus_compute/foo"):
+        shutil.rmtree(f"{os.environ['HOME']}/.globus_compute/foo")
+    if os.path.exists(f"{pwd}/.globus_compute/bar"):
+        shutil.rmtree(f"{pwd}/.globus_compute/bar")
+
+    # Configure an endpoint without a config_dir
+    endpoint.configure("foo")
+    assert os.path.exists(f"{os.environ['HOME']}/.globus_compute/foo/config.yaml")
+
+    # Configure an endpoint with a config_dir
+    endpoint.configure("bar", config_dir=f"{pwd}/.globus_compute")
+    assert os.path.exists(f"{pwd}/.globus_compute/bar/config.yaml")
+
+    # Set init_blocks in configs to 0 so we don't have to wait for workers
+    # to shut down before we can delete the endpoint
+    for filename in [
+        f"{os.environ['HOME']}/.globus_compute/foo/config.yaml",
+        f"{pwd}/.globus_compute/bar/config.yaml",
+    ]:
+        with open(filename, "r") as file:
+            config = file.read()
+            new_config = config.replace("init_blocks: 1", "init_blocks: 0")
+        with open(filename, "w") as file:
+            file.write(new_config)
+
+
+def test_endpoint_list_nonempty_initialized():
+    pwd = pathlib.Path(__file__).parent.resolve()
+    # List endpoints without a config_dir
+    ep_list = endpoint.list()
+    assert ep_list["foo"] == {"id": "None", "state": "Initialized"}
+    # List endpoints with a config_dir
+    ep_list = endpoint.list(config_dir=f"{pwd}/.globus_compute")
+    assert ep_list["bar"] == {"id": "None", "state": "Initialized"}
+
+
+def test_endpoint_start():
+    pwd = pathlib.Path(__file__).parent.resolve()
+    # Start an endpoint without a config_dir
+    endpoint.start("foo")
+    # Start an endpoint with a config_dir
+    endpoint.start("bar", config_dir=f"{pwd}/.globus_compute")
+    # Verify they are running
+    ep_list = endpoint.list()
+    assert ep_list["foo"]["state"] == "Running"
+    assert len(ep_list["foo"]["id"]) == 36
+    ep_list = endpoint.list(config_dir=f"{pwd}/.globus_compute")
+    assert ep_list["bar"]["state"] == "Running"
+    assert len(ep_list["bar"]["id"]) == 36
+
+
+def test_endpoint_stop():
+    pwd = pathlib.Path(__file__).parent.resolve()
+    # Stop an endpoint without a config_dir
+    endpoint.stop("foo")
+    # Stop an endpoint with a config_dir
+    endpoint.stop("bar", config_dir=f"{pwd}/.globus_compute")
+    # Verify they are stopped
+    ep_list = endpoint.list()
+    assert ep_list["foo"]["state"] == "Stopped"
+    assert len(ep_list["foo"]["id"]) == 36
+    ep_list = endpoint.list(config_dir=f"{pwd}/.globus_compute")
+    assert ep_list["bar"]["state"] == "Stopped"
+    assert len(ep_list["bar"]["id"]) == 36
+
+
+def test_endpoint_delete():
+    pwd = pathlib.Path(__file__).parent.resolve()
+    # Delete an endpoint without a config_dir
+    endpoint.delete("foo")
+    # Delete an endpoint with a config_dir
+    endpoint.delete("bar", config_dir=f"{pwd}/.globus_compute")
+    # Verify they are deleted
+    assert not os.path.exists(f"{os.environ['HOME']}/.globus_compute/foo")
+    assert not os.path.exists(f"{pwd}/.globus_compute/bar")


### PR DESCRIPTION
This update adds a new CLI and a corresponding API for managing Globus Compute endpoints.  The API runs the corresponding `globus-compute-endpoint` commands as a subprocess and may be called from other parts of the code when endpoints need to be configured/started/stopped/deleted.  The CLI introduces a new `chiltepin endpoint` command for managing the endpoints.  It calls the corresponding API routines.  While a bit redundant with the `globus-compute-endpoint` CLI, it allows hiding of certain behaviors we don't want to expose to the user.  Those will become more evident when multi-user endpoints are introduced.

Closes #134 and #137