### PR TITLE
Add endpoint login/logout and Globus Transfer task

### DIFF
--- a/src/chiltepin/cli.py
+++ b/src/chiltepin/cli.py
@@ -22,6 +22,20 @@ cmd_parsers = root_parser.add_subparsers(
     help="Chiltepin commands",
 )
 
+# Add parser for the login command
+login_parser = cmd_parsers.add_parser(
+    "login",
+    help="login to the Chiltepin App",
+)
+login_parser.set_defaults(func=endpoint.login)
+
+# Add parser for the login command
+logout_parser = cmd_parsers.add_parser(
+    "logout",
+    help="logout of the Chiltepin App",
+)
+logout_parser.set_defaults(func=endpoint.logout)
+
 # Add parser for the endpoint command
 endpoint_parser = cmd_parsers.add_parser(
     "endpoint",

--- a/src/chiltepin/configure.py
+++ b/src/chiltepin/configure.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List
 
 import yaml
-from globus_compute_sdk import Executor
+from globus_compute_sdk import Client, Executor
 from parsl.config import Config
 from parsl.executors import GlobusComputeExecutor, HighThroughputExecutor, MPIExecutor
 from parsl.launchers import SimpleLauncher
@@ -141,7 +141,7 @@ def make_mpi_executor(name: str, config: Dict[str, Any]) -> MPIExecutor:
 
 
 def make_globus_compute_executor(
-    name: str, config: Dict[str, Any]
+    name: str, config: Dict[str, Any], client: Client | None = None
 ) -> GlobusComputeExecutor:
     """Construct a GlobusComputeExecutor from the input configuration
 
@@ -175,6 +175,10 @@ def make_globus_compute_executor(
         "walltime":               1:00:00
         "environment":            []
 
+    client: Client | None
+        The Globus Compute client to use for instantiating the GlobusComputeExecutor.
+        If not specified, Globus Compute will instantiate and use a default client.
+
     Returns
     -------
 
@@ -182,7 +186,7 @@ def make_globus_compute_executor(
     """
     e = GlobusComputeExecutor(
         label=name,
-        executor=Executor(endpoint_id=config["endpoint id"]),
+        executor=Executor(endpoint_id=config["endpoint id"], client=client),
         user_endpoint_config={
             "engine": config.get("engine", "GlobusComputeEngine"),
             "max_mpi_apps": config.get("max mpi apps", 1),
@@ -200,7 +204,11 @@ def make_globus_compute_executor(
     return e
 
 
-def load(config: Dict[str, Any], resources: List[str] | None = None) -> Config:
+def load(
+    config: Dict[str, Any],
+    resources: List[str] | None = None,
+    client: Client | None = None,
+) -> Config:
     """Construct a list of Executors from the input configuration dictionary
 
     The list returned by this function can be used to construct a Parsl Config
@@ -219,6 +227,11 @@ def load(config: Dict[str, Any], resources: List[str] | None = None) -> Config:
         If None, all resources are loaded.  Otherwise the resources whose
         labels are in the list will be loaded.
 
+    client: Client | None
+        A Globus Compute client to use when instantiating Globus Compute resources.
+        The default is None.  If None, one will be instantiated automatically for
+        any Globus Compute resources in the configuration.
+
     Returns
     -------
 
@@ -236,8 +249,8 @@ def load(config: Dict[str, Any], resources: List[str] | None = None) -> Config:
                     executors.append(make_mpi_executor(name, spec))
                 case "GlobusComputeEngine":
                     # Make a GlobusComputeExecutor for non-MPI jobs
-                    executors.append(make_globus_compute_executor(name, spec))
+                    executors.append(make_globus_compute_executor(name, spec, client))
                 case "GlobusMPIEngine":
                     # Make a GlobusComputeExecutor for MPI jobs
-                    executors.append(make_globus_compute_executor(name, spec))
+                    executors.append(make_globus_compute_executor(name, spec, client))
     return Config(executors)

--- a/src/chiltepin/configure.py
+++ b/src/chiltepin/configure.py
@@ -5,7 +5,7 @@ from globus_compute_sdk import Client, Executor
 from parsl.config import Config
 from parsl.executors import GlobusComputeExecutor, HighThroughputExecutor, MPIExecutor
 from parsl.launchers import SimpleLauncher
-from parsl.providers import SlurmProvider
+from parsl.providers import LocalProvider, SlurmProvider
 
 
 def parse_file(filename: str) -> Dict[str, Any]:
@@ -237,7 +237,17 @@ def load(
 
     Config
     """
-    executors = []
+    executors = [
+        HighThroughputExecutor(
+            label="local",
+            worker_debug=True,
+            cores_per_worker=1,
+            provider=LocalProvider(
+                init_blocks=0,
+                max_blocks=1,
+            ),
+        )
+    ]
     for name, spec in config.items():
         if resources is None or name in resources:
             match spec["engine"]:

--- a/src/chiltepin/data.py
+++ b/src/chiltepin/data.py
@@ -1,0 +1,325 @@
+from concurrent.futures import Future
+
+from globus_sdk import TransferClient
+
+import chiltepin.endpoint as endpoint
+from chiltepin.tasks import python_task
+
+
+@python_task
+def transfer_task(
+    src_ep: str,
+    dst_ep: str,
+    src_path: str,
+    dst_path: str,
+    timeout: int = 3600,
+    polling_interval: int = 30,
+    client: TransferClient | None = None,
+    recursive: bool = False,
+    dependencies: Future | None = None,
+):
+    """Trnsfer data asynchronously in a Parsl task
+
+    This wraps synchronous Globus data transfer into a Parsl python_app task.
+    Calling this function will immediately return a future. The result of the
+    future will be True if the transfer completed successfully, or False if
+    it did not.
+
+    Parameters
+    ----------
+
+    src_ep: str
+        Name of the source endpoint for the transfer.  Can be a display name
+        or a UUID string.
+
+    dst_ep: str
+        Name of the destination endpoint for the transfer.  Can be a display
+        name or a UUID string.
+
+    src_path: str
+        Path to the file or directory on the source endpoint that is to be
+        transferred.
+
+    dst_path: str
+        Path to the file or directory on the destination endpoint where the
+        data is to be transferred.
+
+    timeout: int
+        Number of seconds to wait for the transfer to complete.
+
+    polling_interval: int
+        Number of seconds to wait between checking the status of the transfer
+
+    client: TransferClient | None
+        Transfer client to use for submitting the transfers. If None, one
+        will be retreived via the login process. If a login has already been
+        performed, no login flow prompts will be issued.
+
+    recursive: bool
+        Whether or not a recursive transfer should be performed
+
+    dependencies: Future | None
+        Future to wait for completion before running the transfer task. If
+        None, the transfer will be run at the next available scheduling
+        opportunity
+    """
+    # Run the transfer
+    completed = transfer(
+        src_ep,
+        dst_ep,
+        src_path,
+        dst_path,
+        timeout=3600,
+        polling_interval=30,
+        client=None,
+        recursive=False,
+    )
+    return completed
+
+
+@python_task
+def delete_task(
+    src_ep: str,
+    src_path: str,
+    timeout: int = 3600,
+    polling_interval: int = 30,
+    client: TransferClient | None = None,
+    recursive: bool = False,
+    dependencies: Future | None = None,
+):
+    """Delete data asynchronously in a Parsl task
+
+    This wraps synchronous Globus data deletion into a Parsl python_app task.
+    Calling this function will immediately return a future. The result of the
+    future will be True if the deletion completed successfully, or False if
+    it did not.
+
+    Parameters
+    ----------
+
+    src_ep: str
+        Name of the source endpoint for the data to be deletd.  Can be a
+        display name or a UUID string.
+
+    src_path: str
+        Path to the file or directory on the source endpoint that is to be
+        deleted.
+
+    timeout: int
+        Number of seconds to wait for the deletion to complete.
+
+    polling_interval: int
+        Number of seconds to wait between checking the status of the deletion
+
+    client: TransferClient | None
+        Transfer client to use for submitting the deletion. If None, one
+        will be retreived via the login process. If a login has already been
+        performed, no login flow prompts will be issued.  NOTE: Yes, deletion
+        is done using a TransferClient.
+
+    recursive: bool
+        Whether or not a recursive deletion should be performed
+
+    dependencies: Future | None
+        Future to wait for completion before running the deletion task. If
+        None, the deletion will be run at the next available scheduling
+        opportunity
+    """
+    completed = delete(
+        src_ep,
+        src_path,
+        timeout=3600,
+        polling_interval=30,
+        client=None,
+        recursive=False,
+    )
+    return completed
+
+
+def transfer(
+    src_ep: str,
+    dst_ep: str,
+    src_path: str,
+    dst_path: str,
+    timeout: int = 3600,
+    polling_interval: int = 30,
+    client: TransferClient | None = None,
+    recursive: bool = False,
+):
+    """Trnsfer data synchronously with Globus
+
+    This performs a Globus transfer of data from one Globus transfer endpoint
+    to another.
+
+    Parameters
+    ----------
+
+    src_ep: str
+        Name of the source endpoint for the transfer.  Can be a display name
+        or a UUID string.
+
+    dst_ep: str
+        Name of the destination endpoint for the transfer.  Can be a display
+        name or a UUID string.
+
+    src_path: str
+        Path to the file or directory on the source endpoint that is to be
+        transferred.
+
+    dst_path: str
+        Path to the file or directory on the destination endpoint where the
+        data is to be transferred.
+
+    timeout: int
+        Number of seconds to wait for the transfer to complete.
+
+    polling_interval: int
+        Number of seconds to wait between checking the status of the transfer
+
+    client: TransferClient | None
+        Transfer client to use for submitting the transfers. If None, one
+        will be retreived via the login process. If a login has already been
+        performed, no login flow prompts will be issued.
+
+    recursive: bool
+        Whether or not a recursive transfer should be performed
+    """
+    import globus_sdk
+
+    # Get transfer client
+    if not client:
+        clients = endpoint.login()
+        client = clients["transfer"]
+
+    # Get the source endpoint
+    src_id = None
+    for ep in client.endpoint_search(src_ep, filter_non_functional=False):
+        if ep["display_name"] == src_ep or ep["id"] == src_ep:
+            src_id = ep["id"]
+    if not src_id:
+        raise Exception(f"Source endpoint '{src_ep}' could not be found")
+
+    # Get the destination endpoint
+    dst_id = None
+    for ep in client.endpoint_search(dst_ep, filter_non_functional=False):
+        if ep["display_name"] == dst_ep or ep["id"] == dst_ep:
+            dst_id = ep["id"]
+    if not dst_id:
+        raise Exception(f"Destination endpoint '{dst_ep}' could not be found")
+
+    # Add data access scopes for both endpoints (just in case)
+    # client.add_app_data_access_scope([src_id, dst_id])
+
+    # Build the transfer data
+    task_data = globus_sdk.TransferData(
+        client,
+        source_endpoint=src_id,
+        destination_endpoint=dst_id,
+    )
+    task_data.add_item(
+        src_path,
+        dst_path,
+        recursive=recursive,
+    )
+
+    # Submit the transfer request
+    try:
+        task_doc = client.submit_transfer(task_data)
+        task_id = task_doc["task_id"]
+        done = client.task_wait(
+            task_id, timeout=timeout, polling_interval=polling_interval
+        )
+        return done
+    except globus_sdk.TransferAPIError as err:
+        if err.info.consent_required:
+            raise Exception(
+                "Encountered a ConsentRequired error.\n"
+                "You must login a second time to grant consents.\n\n"
+                "err.info"
+            )
+        else:
+            raise Exception(err)
+
+
+def delete(
+    src_ep: str,
+    src_path: str,
+    timeout: int = 3600,
+    polling_interval: int = 30,
+    client: TransferClient | None = None,
+    recursive: bool = False,
+):
+    """Delete data asynchronously in a Parsl task
+
+    This wraps synchronous Globus data deletion into a Parsl python_app task.
+    Calling this function will immediately return a future. The result of the
+    future will be True if the deletion completed successfully, or False if
+    it did not.
+
+    Parameters
+    ----------
+
+    src_ep: str
+        Name of the source endpoint for the data to be deletd.  Can be a
+        display name or a UUID string.
+
+    src_path: str
+        Path to the file or directory on the source endpoint that is to be
+        deleted.
+
+    timeout: int
+        Number of seconds to wait for the deletion to complete.
+
+    polling_interval: int
+        Number of seconds to wait between checking the status of the deletion
+
+    client: TransferClient | None
+        Transfer client to use for submitting the deletion. If None, one
+        will be retreived via the login process. If a login has already been
+        performed, no login flow prompts will be issued.  NOTE: Yes, deletion
+        is done using a TransferClient.
+
+    recursive: bool
+        Whether or not a recursive deletion should be performed
+    """
+    import globus_sdk
+
+    # Get transfer client
+    if not client:
+        clients = endpoint.login()
+        client = clients["transfer"]
+
+    # Get the source endpoint
+    src_id = None
+    for ep in client.endpoint_search(src_ep, filter_non_functional=False):
+        if ep["display_name"] == src_ep or ep["id"] == src_ep:
+            src_id = ep["id"]
+    if not src_id:
+        raise Exception(f"Source endpoint '{src_ep}' could not be found")
+
+    # Add data access scopes for both endpoints (just in case)
+    # client.add_app_data_access_scope([src_id, dst_id])
+
+    # Build the delete data payload
+    task_data = globus_sdk.DeleteData(client, src_id, recursive=True)
+    task_data.add_item(src_path)
+
+    # Submit the deletion request
+    try:
+        task_doc = client.submit_delete(task_data)
+        task_id = task_doc["task_id"]
+        done = client.task_wait(
+            task_id,
+            timeout=timeout,
+            polling_interval=polling_interval,
+        )
+        return done
+    except globus_sdk.TransferAPIError as err:
+        if err.info.consent_required:
+            raise Exception(
+                "Encountered a ConsentRequired error.\n"
+                "You must login a second time to grant consents.\n\n"
+                "err.info"
+            )
+        else:
+            raise Exception(err)

--- a/src/chiltepin/endpoint.py
+++ b/src/chiltepin/endpoint.py
@@ -9,7 +9,8 @@ from typing import Dict
 import yaml
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.auth.globus_app import get_globus_app
-from globus_sdk import TransferClient
+from globus_sdk import ClientApp, GlobusApp, TransferClient, UserApp
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 multi_endpoint_template = """# This is the default user-template provided with newly-configured Multi-User
 # endpoints.  User endpoints generate a user-endpoint-specific configuration by
@@ -73,17 +74,78 @@ idle_heartbeats_soft: 10
 idle_heartbeats_hard: 5760
 """
 
-
 # Set the UUID of the default Chiltepin thick client
 CHILTEPIN_CLIENT_UUID = "42e9e804-0bcd-4c3d-881b-8e270e3c2163"
+
+
+def get_chiltepin_apps() -> (GlobusApp, GlobusApp):
+    """Log in to the Chiltepin app
+
+    This instantiates GlobusApp objects for use in creating Globus Compute
+    and Globus Transfer clients.  If the environment contains settings that
+    specify client ids and/or client secrets, those will be used to create the
+    Globus Apps.  Otherwise, the default Chiltepin thick client will be used.
+    If a secret is present in the environment, ClientApp objects will be created.
+    Otherwise, UserApp objects will be created. This is used by the login() and
+    logout() functions where login and logout flows are initiated after the apps
+    are retreived. A tuple is returned where the first item is the compute app
+    and the second item is the transfer app.
+
+    Returns
+    -------
+
+    (GlobusApp, GlobusApp)
+    """
+    # Get client id and secret from environment if they are set
+    client_id = os.environ.get("GLOBUS_COMPUTE_CLIENT_ID", None)
+    client_secret = os.environ.get("GLOBUS_COMPUTE_CLIENT_SECRET", None)
+
+    # If a client secret was found, make sure a client id was also found
+    if client_secret and not client_id:
+        raise Exception(
+            "$GLOBUS_COMPUTE_CLIENT_SECRET is set but $GLOBUS_COMPUTE_CLIENT_ID is not"
+        )
+
+    # If a secret and id were both found, set the corresponding Globus CLI env vars
+    if client_secret:
+        os.environ["GLOBUS_CLI_CLIENT_ID"] = client_id
+        os.environ["GLOBUS_CLI_CLIENT_SECRET"] = client_secret
+
+    # If a client id was not found in the environment, use the default Chiltepin client id
+    if not client_id:
+        client_id = CHILTEPIN_CLIENT_UUID
+        os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = client_id
+        # NOTE: $GLOBUS_CLI_CLIENT_ID should only be set if $GLOBUS_CLI_CLIENT_SECRET is also set
+
+    # Get the Globus App the compute client will use
+    compute_app = get_globus_app()
+
+    # Create a Globus App for the transfer client
+    if client_secret:
+        # Use a ClientApp for Service Client credentials
+        transfer_app = ClientApp(
+            "chiltepin",
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    else:
+        # Use a UserApp for user credentials
+        transfer_app = UserApp(
+            "chiltepin",
+            client_id=client_id,
+        )
+
+    # Return the Apps
+    return (compute_app, transfer_app)
 
 
 def login() -> Dict[str, Client | TransferClient]:
     """Log in to the Chiltepin app
 
-    This initiates the Globus login flow to log the user in to the registered
-    Chiltepin thick client app. It uses those credentials to instantiate and
-    return a Globus Compute client and a Globus Transfer client in a dictionary.
+    This initiates the Globus login flow to log the user in to the Globus compute
+    and transfer services. The login will use the registered Chiltepin thick client
+    by default, or the client id and/or secret specified in the environment. This
+    returns a Globus Compute client and a Globus Transfer client in a dictionary.
     Those clients can then be used for accessing those services.
 
     Returns
@@ -91,32 +153,43 @@ def login() -> Dict[str, Client | TransferClient]:
 
     Dict[str, Client | TransferClient]
     """
-    # Ensure appropriate client app is specified
-    if os.environ["GLOBUS_COMPUTE_CLIENT_SECRET"]:
-        if not os.environ["GLOBUS_COMPUTE_CLIENT_ID"]:
-            raise Exception(
-                "$GLOBUS_COMPUTE_CLIENT_SECRET is set but $GLOBUS_COMPUTE_CLIENT_ID is not"
+    # Get the Globus Apps for use in creating the clients
+    compute_app, transfer_app = get_chiltepin_apps()
+
+    # Initialize the compute client
+    compute_client = Client(app=compute_app)
+
+    # Initialize the transfer client
+    transfer_client = TransferClient(app=transfer_app)
+
+    # transfer_client.add_app_data_access_scope("d75f3e86-df3c-4734-8b9d-f182346b4bbd")
+
+    # Initiate login for compute client if necessary
+    if compute_app.login_required():
+        compute_app.login()
+
+    # Initiate login for transfer client if necessary
+    if transfer_app.login_required():
+        transfer_app.login(
+            auth_params=GlobusAuthorizationParameters(
+                session_required_single_domain=["rdhpcs.noaa.gov"],
+                prompt="login",
             )
-    else:
-        if not os.environ["GLOBUS_COMPUTE_CLIENT_ID"]:
-            os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = CHILTEPIN_CLIENT_UUID
-    app = get_globus_app()
-    compute_client = Client(app=app)
-    transfer_client = TransferClient(app=app)
-    if app.login_required():
-        app.login()
+        )
+
     return {"compute": compute_client, "transfer": transfer_client}
 
 
 def logout():
     """Log out of the Chiltepin app
 
-    This logs the user out of the Chiltepin thick client app and revokes all
-    credentials associated with it.
+    This logs the user out of the Globus compute and transfer services and revokes
+    all credentials associated with them.
     """
-    os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = CHILTEPIN_CLIENT_UUID
-    app = get_globus_app()
-    app.logout()
+    # Get the Globus Apps for use in creating the clients
+    compute_app, transfer_app = get_chiltepin_apps()
+    compute_app.logout()
+    transfer_app.logout()
 
 
 def configure(

--- a/src/chiltepin/endpoint.py
+++ b/src/chiltepin/endpoint.py
@@ -74,6 +74,7 @@ idle_heartbeats_hard: 5760
 """
 
 
+# Set the UUID of the default Chiltepin thick client
 CHILTEPIN_CLIENT_UUID = "42e9e804-0bcd-4c3d-881b-8e270e3c2163"
 
 
@@ -90,7 +91,15 @@ def login() -> Dict[str, Client | TransferClient]:
 
     Dict[str, Client | TransferClient]
     """
-    os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = CHILTEPIN_CLIENT_UUID
+    # Ensure appropriate client app is specified
+    if os.environ["GLOBUS_COMPUTE_CLIENT_SECRET"]:
+        if not os.environ["GLOBUS_COMPUTE_CLIENT_ID"]:
+            raise Exception(
+                "$GLOBUS_COMPUTE_CLIENT_SECRET is set but $GLOBUS_COMPUTE_CLIENT_ID is not"
+            )
+    else:
+        if not os.environ["GLOBUS_COMPUTE_CLIENT_ID"]:
+            os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = CHILTEPIN_CLIENT_UUID
     app = get_globus_app()
     compute_client = Client(app=app)
     transfer_client = TransferClient(app=app)

--- a/src/chiltepin/endpoint.py
+++ b/src/chiltepin/endpoint.py
@@ -7,6 +7,9 @@ import time
 from typing import Dict
 
 import yaml
+from globus_compute_sdk import Client
+from globus_compute_sdk.sdk.auth.globus_app import get_globus_app
+from globus_sdk import TransferClient
 
 multi_endpoint_template = """# This is the default user-template provided with newly-configured Multi-User
 # endpoints.  User endpoints generate a user-endpoint-specific configuration by
@@ -69,6 +72,42 @@ idle_heartbeats_soft: 10
 # idle_heartbeats_soft is 0 or not set.)
 idle_heartbeats_hard: 5760
 """
+
+
+CHILTEPIN_CLIENT_UUID = "42e9e804-0bcd-4c3d-881b-8e270e3c2163"
+
+
+def login() -> Dict[str, Client | TransferClient]:
+    """Log in to the Chiltepin app
+
+    This initiates the Globus login flow to log the user in to the registered
+    Chiltepin thick client app. It uses those credentials to instantiate and
+    return a Globus Compute client and a Globus Transfer client in a dictionary.
+    Those clients can then be used for accessing those services.
+
+    Returns
+    -------
+
+    Dict[str, Client | TransferClient]
+    """
+    os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = CHILTEPIN_CLIENT_UUID
+    app = get_globus_app()
+    compute_client = Client(app=app)
+    transfer_client = TransferClient(app=app)
+    if app.login_required():
+        app.login()
+    return {"compute": compute_client, "transfer": transfer_client}
+
+
+def logout():
+    """Log out of the Chiltepin app
+
+    This logs the user out of the Chiltepin thick client app and revokes all
+    credentials associated with it.
+    """
+    os.environ["GLOBUS_COMPUTE_CLIENT_ID"] = CHILTEPIN_CLIENT_UUID
+    app = get_globus_app()
+    app.logout()
 
 
 def configure(

--- a/src/chiltepin/jedi/qg/wrapper.py
+++ b/src/chiltepin/jedi/qg/wrapper.py
@@ -94,9 +94,9 @@ class QG:
         jobs=8,
         stdout=None,
         stderr=None,
-        clone_executor="service",
-        configure_executor="service",
-        make_executor="compute",
+        clone_executor=["service"],
+        configure_executor=["service"],
+        make_executor=["compute"],
     ):
         clone = self.clone(
             stdout=(stdout, "w"),

--- a/src/chiltepin/mpas/wrapper.py
+++ b/src/chiltepin/mpas/wrapper.py
@@ -1,8 +1,9 @@
 import textwrap
 from datetime import datetime
 
-from chiltepin.tasks import bash_task, join_task
 from uwtools.api import config as uwconfig
+
+from chiltepin.tasks import bash_task, join_task
 
 
 class MPAS:

--- a/src/chiltepin/mpas/wrapper.py
+++ b/src/chiltepin/mpas/wrapper.py
@@ -1,9 +1,8 @@
 import textwrap
 from datetime import datetime
 
-from uwtools.api import config as uwconfig
-
 from chiltepin.tasks import bash_task, join_task
+from uwtools.api import config as uwconfig
 
 
 class MPAS:

--- a/src/chiltepin/tasks.py
+++ b/src/chiltepin/tasks.py
@@ -32,7 +32,7 @@ def python_task(function: Callable) -> Callable:
         executor="all",
         **kwargs,
     ):
-        return python_app(function, executors=[executor])(*args, **kwargs)
+        return python_app(function, executors=executor)(*args, **kwargs)
 
     return function_wrapper
 
@@ -66,7 +66,7 @@ def bash_task(function: Callable) -> Callable:
         executor="all",
         **kwargs,
     ):
-        return bash_app(function, executors=[executor])(*args, **kwargs)
+        return bash_app(function, executors=executor)(*args, **kwargs)
 
     return function_wrapper
 

--- a/tests/test_globus_compute_mep_hello.py
+++ b/tests/test_globus_compute_mep_hello.py
@@ -15,6 +15,10 @@ from chiltepin.tasks import python_task
 def config(config_file, platform):
     pwd = pathlib.Path(__file__).parent.resolve()
 
+    # Log in
+    clients = endpoint.login()
+    compute_client = clients["compute"]
+
     # Parse the configuration for the chosen platform
     yaml_config = chiltepin.configure.parse_file(config_file)
     resource_config = yaml_config[platform]["resources"]
@@ -35,7 +39,11 @@ def config(config_file, platform):
     resource_config = _set_endpoint_ids(resource_config)
 
     # Load the finalized resource configuration
-    resources = chiltepin.configure.load(resource_config, resources=["gc-service"])
+    resources = chiltepin.configure.load(
+        resource_config,
+        resources=["gc-service"],
+        client=compute_client,
+    )
 
     # Run the tests with the loaded resources
     with parsl.load(resources):

--- a/tests/test_globus_compute_mep_hello.py
+++ b/tests/test_globus_compute_mep_hello.py
@@ -77,5 +77,5 @@ def test_hello_endpoint(config):
     def hello():
         return "Hello"
 
-    future = hello(executor="gc-service")
+    future = hello(executor=["gc-service"])
     assert future.result() == "Hello"

--- a/tests/test_globus_compute_mep_mpi.py
+++ b/tests/test_globus_compute_mep_mpi.py
@@ -126,7 +126,7 @@ def test_endpoint_mpi_hello(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_hello_compile_mep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_hello_compile_mep.err"),
-        executor="gc-compute",
+        executor=["gc-compute"],
     )
     r = future.result()
     assert r == 0
@@ -135,7 +135,7 @@ def test_endpoint_mpi_hello(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_hello_run_mep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_hello_run_mep.err"),
-        executor="gc-mpi",
+        executor=["gc-mpi"],
         parsl_resource_specification={
             "num_nodes": 3,  # Number of nodes required for the application instance
             "num_ranks": 6,  # Number of ranks in total
@@ -190,7 +190,7 @@ def test_endpoint_mpi_pi(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_pi_compile_mep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_pi_compile_mep.err"),
-        executor="gc-compute",
+        executor=["gc-compute"],
     )
     r = future.result()
     assert r == 0
@@ -199,7 +199,7 @@ def test_endpoint_mpi_pi(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_pi1_run_mep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_pi1_run_mep.err"),
-        executor="gc-mpi",
+        executor=["gc-mpi"],
         parsl_resource_specification={
             "num_nodes": 2,  # Number of nodes required for the application instance
             "num_ranks": 2 * cores_per_node,  # Number of ranks in total
@@ -211,7 +211,7 @@ def test_endpoint_mpi_pi(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_pi2_run_mep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_pi2_run_mep.err"),
-        executor="gc-mpi",
+        executor=["gc-mpi"],
         parsl_resource_specification={
             "num_nodes": 1,  # Number of nodes required for the application instance
             "num_ranks": cores_per_node,  # Number of ranks in total

--- a/tests/test_globus_compute_mep_mpi.py
+++ b/tests/test_globus_compute_mep_mpi.py
@@ -18,6 +18,10 @@ from chiltepin.tasks import bash_task
 def config(config_file, platform):
     pwd = pathlib.Path(__file__).parent.resolve()
 
+    # Log in
+    clients = endpoint.login()
+    compute_client = clients["compute"]
+
     # Parse the configuration for the chosen platform
     yaml_config = chiltepin.configure.parse_file(config_file)
     resource_config = yaml_config[platform]["resources"]
@@ -44,6 +48,7 @@ def config(config_file, platform):
     resources = chiltepin.configure.load(
         resource_config,
         resources=["gc-compute", "gc-mpi"],
+        client=compute_client,
     )
 
     # Run the tests with the loaded resources

--- a/tests/test_globus_compute_uep_hello.py
+++ b/tests/test_globus_compute_uep_hello.py
@@ -15,6 +15,10 @@ from chiltepin.tasks import python_task
 def config(config_file, platform):
     pwd = pathlib.Path(__file__).parent.resolve()
 
+    # Log in
+    clients = endpoint.login()
+    compute_client = clients["compute"]
+
     # Parse the configuration for the chosen platform
     yaml_config = chiltepin.configure.parse_file(config_file)
     resource_config = yaml_config[platform]["resources"]
@@ -38,7 +42,11 @@ def config(config_file, platform):
     resource_config = _set_endpoint_ids(resource_config)
 
     # Load the finalized resource configuration
-    resources = chiltepin.configure.load(resource_config, resources=["gc-service"])
+    resources = chiltepin.configure.load(
+        resource_config,
+        resources=["gc-service"],
+        client=compute_client,
+    )
 
     # Run the tests with the loaded resources
     with parsl.load(resources):

--- a/tests/test_globus_compute_uep_hello.py
+++ b/tests/test_globus_compute_uep_hello.py
@@ -98,5 +98,5 @@ def test_hello_endpoint(config):
     def hello():
         return "Hello"
 
-    future = hello(executor="gc-service")
+    future = hello(executor=["gc-service"])
     assert future.result() == "Hello"

--- a/tests/test_globus_compute_uep_mpi.py
+++ b/tests/test_globus_compute_uep_mpi.py
@@ -18,6 +18,10 @@ from chiltepin.tasks import bash_task
 def config(config_file, platform):
     pwd = pathlib.Path(__file__).parent.resolve()
 
+    # Log in
+    clients = endpoint.login()
+    compute_client = clients["compute"]
+
     # Parse the configuration for the chosen platform
     yaml_config = chiltepin.configure.parse_file(config_file)
     resource_config = yaml_config[platform]["resources"]
@@ -49,6 +53,7 @@ def config(config_file, platform):
     resources = chiltepin.configure.load(
         resource_config,
         resources=["gc-compute", "gc-mpi"],
+        client=compute_client,
     )
 
     # Run the tests with the loaded resources

--- a/tests/test_globus_compute_uep_mpi.py
+++ b/tests/test_globus_compute_uep_mpi.py
@@ -152,7 +152,7 @@ def test_endpoint_mpi_hello(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_hello_compile_uep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_hello_compile_uep.err"),
-        executor="gc-compute",
+        executor=["gc-compute"],
     )
     r = future.result()
     assert r == 0
@@ -161,7 +161,7 @@ def test_endpoint_mpi_hello(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_hello_run_uep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_hello_run_uep.err"),
-        executor="gc-mpi",
+        executor=["gc-mpi"],
         parsl_resource_specification={
             "num_nodes": 3,  # Number of nodes required for the application instance
             "num_ranks": 6,  # Number of ranks in total
@@ -216,7 +216,7 @@ def test_endpoint_mpi_pi(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_pi_compile_uep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_pi_compile_uep.err"),
-        executor="gc-compute",
+        executor=["gc-compute"],
     )
     r = future.result()
     assert r == 0
@@ -225,7 +225,7 @@ def test_endpoint_mpi_pi(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_pi1_run_uep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_pi1_run_uep.err"),
-        executor="gc-mpi",
+        executor=["gc-mpi"],
         parsl_resource_specification={
             "num_nodes": 2,  # Number of nodes required for the application instance
             "num_ranks": 2 * cores_per_node,  # Number of ranks in total
@@ -237,7 +237,7 @@ def test_endpoint_mpi_pi(config):
         pwd,
         stdout=os.path.join(pwd, "globus_compute_mpi_pi2_run_uep.out"),
         stderr=os.path.join(pwd, "globus_compute_mpi_pi2_run_uep.err"),
-        executor="gc-mpi",
+        executor=["gc-mpi"],
         parsl_resource_specification={
             "num_nodes": 1,  # Number of nodes required for the application instance
             "num_ranks": cores_per_node,  # Number of ranks in total

--- a/tests/test_parsl_mpi_hello.py
+++ b/tests/test_parsl_mpi_hello.py
@@ -142,8 +142,8 @@ def test_run_mpi_pi(config):
         os.remove(pwd / "parsl_mpi_pi2_run.out")
     if os.path.exists(pwd / "parsl_mpi_pi2_run.err"):
         os.remove(pwd / "parsl_mpi_pi2_run.err")
-    cores_per_node = config["resources"].executors[0].provider.cores_per_node
-    assert config["resources"].executors[0].label == "mpi"
+    cores_per_node = config["resources"].executors[1].provider.cores_per_node
+    assert config["resources"].executors[1].label == "mpi"
     pi1 = run_mpi_pi(
         dirpath=pwd,
         stdout=os.path.join(pwd, "parsl_mpi_pi1_run.out"),

--- a/tests/test_qg_install.py
+++ b/tests/test_qg_install.py
@@ -41,9 +41,9 @@ def test_qg_install(config):
         jobs=8,
         stdout=pwd / "qg_install.out",
         stderr=pwd / "qg_install.err",
-        clone_executor="service",
-        configure_executor="service",
-        make_executor="compute",
+        clone_executor=["service"],
+        configure_executor=["service"],
+        make_executor=["compute"],
     ).result()
 
     assert install_result == 0

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,48 @@
+import parsl
+import pytest
+
+import chiltepin.configure
+import chiltepin.data as data
+import chiltepin.endpoint as endpoint
+
+
+# Set up fixture to initialize and cleanup Parsl
+@pytest.fixture(scope="module")
+def config(config_file, platform):
+    # Log in
+    endpoint.login()
+
+    # Load the default resource configuration
+    resources = chiltepin.configure.load({})
+
+    # Run the tests with the loaded resources
+    with parsl.load(resources):
+        yield
+
+
+def test_data_transfer(config):
+    transfer_future = data.transfer_task(
+        "chiltepin-test-niagara",
+        "chiltepin-test-hera",
+        "1MB",
+        "1MB.from_niagara",
+        timeout=120,
+        polling_interval=10,
+        executor=["local"],
+    )
+    completed = transfer_future.result()
+
+    assert completed is True
+
+
+def test_data_delete(config):
+    delete_future = data.delete_task(
+        "chiltepin-test-hera",
+        "1MB.from_niagara",
+        timeout=120,
+        polling_interval=10,
+        executor=["local"],
+    )
+    completed = delete_future.result()
+
+    assert completed is True

--- a/tests/xfer.py
+++ b/tests/xfer.py
@@ -1,5 +1,6 @@
-import chiltepin.endpoint as endpoint
 import globus_sdk
+
+import chiltepin.endpoint as endpoint
 
 clients = endpoint.login()
 transfer_client = clients["transfer"]
@@ -33,31 +34,29 @@ for ep in transfer_client.endpoint_search("msuhpc2", filter_non_functional=False
             HERCULES = ep["id"]
             HERCULES_PATH = "/work/noaa/gsd-hpcs/charrop/hercules/SENA/ExascaleWorkflowSandbox.transfer/tests/1GB"
 
-#src_ep = HARROP_LAPTOP
-#src_path = HARROP_PATH
+# src_ep = HARROP_LAPTOP
+# src_path = HARROP_PATH
 src_ep = HERA
 src_path = HERA_PATH
 
 dst_ep = HERCULES
 dst_path = HERCULES_PATH
-#dst_ep = NIAGARA
-#dst_path = NIAGARA_PATH
-#dst_ep = HERA
-#dst_path = HERA_PATH
-#dst_ep = JET
-#dst_path = JET_PATH
+# dst_ep = NIAGARA
+# dst_path = NIAGARA_PATH
+# dst_ep = HERA
+# dst_path = HERA_PATH
+# dst_ep = JET
+# dst_path = JET_PATH
 
-task_data = globus_sdk.TransferData(
-    source_endpoint=src_ep, destination_endpoint=dst_ep
-)
+task_data = globus_sdk.TransferData(source_endpoint=src_ep, destination_endpoint=dst_ep)
 task_data.add_item(
     src_path,  # source
     dst_path,  # dest
-    #recursive=True,
+    # recursive=True,
 )
 
 try:
-    #transfer_client.add_app_data_access_scope(dst_ep)
+    # transfer_client.add_app_data_access_scope(dst_ep)
     task_doc = transfer_client.submit_transfer(task_data)
     task_id = task_doc["task_id"]
     print(f"submitted transfer, task_id={task_id}")
@@ -69,16 +68,15 @@ except globus_sdk.TransferAPIError as err:
         "You must login a second time to grant consents.\n\n"
     )
     print(f"{err.info.consent_required.required_scopes}")
-    #clients = endpoint.login()
-    #transfer_client = clients["transfer"]
-    #task_doc = transfer_client.submit_transfer(task_data)
-    #task_id = task_doc["task_id"]
-    #print(f"submitted transfer, task_id={task_id}")
-    
-    #self.login_and_get_transfer_client(
-    #    scopes=err.info.consent_required.required_scopes
-    #)
-    #task_doc = self.transfer_client.submit_transfer(task_data)
-    #task_id = task_doc["task_id"]
-    #print(f"submitted transfer, task_id={task_id}")
-    
+    # clients = endpoint.login()
+    # transfer_client = clients["transfer"]
+    # task_doc = transfer_client.submit_transfer(task_data)
+    # task_id = task_doc["task_id"]
+    # print(f"submitted transfer, task_id={task_id}")
+
+    # self.login_and_get_transfer_client(
+    #     scopes=err.info.consent_required.required_scopes
+    # )
+    # task_doc = self.transfer_client.submit_transfer(task_data)
+    # task_id = task_doc["task_id"]
+    # print(f"submitted transfer, task_id={task_id}")

--- a/tests/xfer.py
+++ b/tests/xfer.py
@@ -1,0 +1,84 @@
+import chiltepin.endpoint as endpoint
+import globus_sdk
+
+clients = endpoint.login()
+transfer_client = clients["transfer"]
+
+# Find my laptop endpoint
+for ep in transfer_client.endpoint_search("harrop-lt", filter_non_functional=False):
+    if ep["display_name"] == "harrop-lt":
+        HARROP_LAPTOP = ep["id"]
+        HARROP_PATH = "/Users/christopher.w.harrop/work/SENA/1GB"
+
+# Find the RDHPCS endpoints
+for ep in transfer_client.endpoint_search("noaardhpcs", filter_non_functional=False):
+    match ep["display_name"]:
+        case "noaardhpcs#niagara_untrusted":
+            NIAGARA = ep["id"]
+            NIAGARA_PATH = "/collab1/data_untrusted/Christopher.W.Harrop/1GB"
+        case "noaardhpcs#hera_untrusted":
+            HERA = ep["id"]
+            HERA_PATH = "/scratch2/data_untrusted/Christopher.W.Harrop/1GB"
+        case "noaardhpcs#jet_untrusted":
+            JET = ep["id"]
+            JET_PATH = "/lfs5/data_untrusted/Christopher.W.Harrop/1GB"
+        case "noaardhpcs#gaea":
+            GAEA = ep["id"]
+            GAEA_PATH = ""
+
+# Find the MSU endpoints
+for ep in transfer_client.endpoint_search("msuhpc2", filter_non_functional=False):
+    match ep["display_name"]:
+        case "msuhpc2#Hercules-dtn":
+            HERCULES = ep["id"]
+            HERCULES_PATH = "/work/noaa/gsd-hpcs/charrop/hercules/SENA/ExascaleWorkflowSandbox.transfer/tests/1GB"
+
+#src_ep = HARROP_LAPTOP
+#src_path = HARROP_PATH
+src_ep = HERA
+src_path = HERA_PATH
+
+dst_ep = HERCULES
+dst_path = HERCULES_PATH
+#dst_ep = NIAGARA
+#dst_path = NIAGARA_PATH
+#dst_ep = HERA
+#dst_path = HERA_PATH
+#dst_ep = JET
+#dst_path = JET_PATH
+
+task_data = globus_sdk.TransferData(
+    source_endpoint=src_ep, destination_endpoint=dst_ep
+)
+task_data.add_item(
+    src_path,  # source
+    dst_path,  # dest
+    #recursive=True,
+)
+
+try:
+    #transfer_client.add_app_data_access_scope(dst_ep)
+    task_doc = transfer_client.submit_transfer(task_data)
+    task_id = task_doc["task_id"]
+    print(f"submitted transfer, task_id={task_id}")
+except globus_sdk.TransferAPIError as err:
+    if not err.info.consent_required:
+        raise
+    print(
+        "Encountered a ConsentRequired error.\n"
+        "You must login a second time to grant consents.\n\n"
+    )
+    print(f"{err.info.consent_required.required_scopes}")
+    #clients = endpoint.login()
+    #transfer_client = clients["transfer"]
+    #task_doc = transfer_client.submit_transfer(task_data)
+    #task_id = task_doc["task_id"]
+    #print(f"submitted transfer, task_id={task_id}")
+    
+    #self.login_and_get_transfer_client(
+    #    scopes=err.info.consent_required.required_scopes
+    #)
+    #task_doc = self.transfer_client.submit_transfer(task_data)
+    #task_id = task_doc["task_id"]
+    #print(f"submitted transfer, task_id={task_id}")
+    


### PR DESCRIPTION
This adds endpoint `login()` and `logout()` functions that are accessible to the CLI.  These obtain credentials for performing both compute and transfer tasks that can then be used in downstream workflow tasks.

A new task is added for performing transfers of data between Globus endpoints.

A new task is also added for performing deletion of data at a Globus endpoint.

This closes #120.  